### PR TITLE
Add `if let` syntax

### DIFF
--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -84,6 +84,7 @@ let jsxAttr = (Location.mknoloc "JSX", Parsetree.PStr [])
 let uncurryAttr = (Location.mknoloc "bs", Parsetree.PStr [])
 let ternaryAttr = (Location.mknoloc "ns.ternary", Parsetree.PStr [])
 let ifLetAttr = (Location.mknoloc "ns.iflet", Parsetree.PStr [])
+let suppressFragileMatchWarningAttr = (Location.mknoloc "warning", Parsetree.PStr [Ast_helper.Str.eval (Ast_helper.Exp.constant (Pconst_string ("-4", None)))])
 let makeBracesAttr loc = (Location.mkloc "ns.braces" loc, Parsetree.PStr [])
 
 type typDefOrExt =
@@ -3070,7 +3071,7 @@ and parseIfLetExpr startPos p =
     Ast_helper.Exp.construct ~loc (Location.mkloc (Longident.Lident "()") loc) None
   in
   let loc = mkLoc startPos p.prevEndPos in
-  Ast_helper.Exp.match_ ~attrs:[ifLetAttr] ~loc conditionExpr [
+  Ast_helper.Exp.match_ ~attrs:[ifLetAttr; suppressFragileMatchWarningAttr] ~loc conditionExpr [
     Ast_helper.Exp.case pattern thenExpr;
     Ast_helper.Exp.case (Ast_helper.Pat.any ()) elseExpr;
   ]

--- a/src/napkin_parsetree_viewer.ml
+++ b/src/napkin_parsetree_viewer.ml
@@ -42,18 +42,6 @@ open Parsetree
     in
     process false [] attrs
 
-  let collectIfExpressions expr =
-    let rec collect acc expr = match expr.pexp_desc with
-    | Pexp_ifthenelse (ifExpr, thenExpr, Some elseExpr) ->
-      collect ((ifExpr, thenExpr)::acc) elseExpr
-    | Pexp_ifthenelse (ifExpr, thenExpr, (None as elseExpr)) ->
-      let ifs = List.rev ((ifExpr, thenExpr)::acc) in
-      (ifs, elseExpr)
-    | _ ->
-      (List.rev acc, Some expr)
-    in
-    collect [] expr
-
   let collectListExpressions expr =
     let rec collect acc expr = match expr.pexp_desc with
     | Pexp_construct ({txt = Longident.Lident "[]"}, _) ->
@@ -165,7 +153,7 @@ open Parsetree
   let filterParsingAttrs attrs =
     List.filter (fun attr ->
       match attr with
-      | ({Location.txt = ("ns.ternary" | "ns.braces" | "bs" | "ns.namedArgLoc")}, _) -> false
+      | ({Location.txt = ("ns.ternary" | "ns.braces" | "bs" | "ns.iflet" | "ns.namedArgLoc")}, _) -> false
       | _ -> true
     ) attrs
 
@@ -269,7 +257,7 @@ open Parsetree
 
   let hasAttributes attrs =
     List.exists (fun attr -> match attr with
-      | ({Location.txt = "bs" | "ns.ternary" | "ns.braces"}, _) -> false
+      | ({Location.txt = "bs" | "ns.ternary" | "ns.braces" | "ns.iflet"}, _) -> false
       | _ -> true
     ) attrs
 
@@ -279,6 +267,52 @@ open Parsetree
         [Nolabel, _parentExpr; Nolabel, _memberExpr]
       ) -> true
     | _ -> false
+
+  let rec hasIfLetAttribute attrs =
+    match attrs with
+    | [] -> false
+    | ({Location.txt="ns.iflet"},_)::_ -> true
+    | _::attrs -> hasIfLetAttribute attrs
+
+  let isIfLetExpr expr = match expr with
+    | {
+        pexp_attributes = attrs;
+        pexp_desc = Pexp_match _
+      } when hasIfLetAttribute attrs -> true
+    | _ -> false
+
+  type ifConditionKind =
+  | If of Parsetree.expression
+  | IfLet of Parsetree.pattern * Parsetree.expression
+
+  let collectIfExpressions expr =
+    let rec collect acc expr = match expr.pexp_desc with
+    | Pexp_ifthenelse (ifExpr, thenExpr, Some elseExpr) ->
+      collect ((If(ifExpr), thenExpr)::acc) elseExpr
+    | Pexp_ifthenelse (ifExpr, thenExpr, (None as elseExpr)) ->
+      let ifs = List.rev ((If(ifExpr), thenExpr)::acc) in
+      (ifs, elseExpr)
+        | Pexp_match (condition, [{
+      pc_lhs = pattern;
+      pc_guard = None;
+      pc_rhs = thenExpr;
+    }; {
+      pc_rhs = {pexp_desc = Pexp_construct ({txt = Longident.Lident "()"}, _)}
+    }]) when isIfLetExpr expr ->
+      let ifs = List.rev ((IfLet(pattern, condition), thenExpr)::acc) in
+      (ifs, None)
+    | Pexp_match (condition, [{
+      pc_lhs = pattern;
+      pc_guard = None;
+      pc_rhs = thenExpr;
+    }; {
+      pc_rhs = elseExpr;
+    }]) when isIfLetExpr expr ->
+      collect ((IfLet(pattern, condition), thenExpr)::acc) elseExpr
+    | _ ->
+      (List.rev acc, Some expr)
+    in
+    collect [] expr
 
   let rec hasTernaryAttribute attrs =
     match attrs with
@@ -371,13 +405,13 @@ open Parsetree
 
   let filterPrinteableAttributes attrs =
     List.filter (fun attr -> match attr with
-      | ({Location.txt="bs" | "ns.ternary"}, _) -> false
+      | ({Location.txt="bs" | "ns.ternary" | "ns.iflet"}, _) -> false
       | _ -> true
     ) attrs
 
   let partitionPrinteableAttributes attrs =
     List.partition (fun attr -> match attr with
-      | ({Location.txt="bs" | "ns.ternary"}, _) -> false
+      | ({Location.txt="bs" | "ns.ternary" | "ns.iflet"}, _) -> false
       | _ -> true
     ) attrs
 

--- a/src/napkin_parsetree_viewer.mli
+++ b/src/napkin_parsetree_viewer.mli
@@ -74,6 +74,7 @@ val parametersShouldHug:
  funParamKind list -> bool
 
 val filterTernaryAttributes: Parsetree.attributes -> Parsetree.attributes
+val filterFragileMatchAttributes: Parsetree.attributes -> Parsetree.attributes
 
 val isJsxExpression: Parsetree.expression -> bool
 val hasJsxAttribute: Parsetree.attributes -> bool

--- a/src/napkin_parsetree_viewer.mli
+++ b/src/napkin_parsetree_viewer.mli
@@ -13,12 +13,16 @@ val functorType: Parsetree.module_type ->
 (* filters @bs out of the provided attributes *)
 val processUncurriedAttribute: Parsetree.attributes -> bool * Parsetree.attributes
 
+type ifConditionKind =
+  | If of Parsetree.expression
+  | IfLet of Parsetree.pattern * Parsetree.expression
+
 (* if ... else if ... else ... is represented as nested expressions: if ... else { if ... }
 * The purpose of this function is to flatten nested ifs into one sequence.
 * Basically compute: ([if, else if, else if, else if], else) *)
 val collectIfExpressions:
  Parsetree.expression ->
-   (Parsetree.expression * Parsetree.expression) list * Parsetree.expression option
+   (ifConditionKind * Parsetree.expression) list * Parsetree.expression option
 
 val collectListExpressions:
  Parsetree.expression -> (Parsetree.expression list * Parsetree.expression option)
@@ -62,6 +66,7 @@ val hasAttributes: Parsetree.attributes -> bool
 
 val isArrayAccess: Parsetree.expression -> bool
 val isTernaryExpr: Parsetree.expression -> bool
+val isIfLetExpr: Parsetree.expression -> bool
 
 val collectTernaryParts: Parsetree.expression -> ((Parsetree.expression * Parsetree.expression) list * Parsetree.expression)
 
@@ -90,7 +95,7 @@ val modExprApply : Parsetree.module_expr -> (
  * Example: given a ptyp_arrow type, what are its arguments and what is the
  * returnType? *)
 
- 
+
 val modExprFunctor : Parsetree.module_expr -> (
  (Parsetree.attributes * string Asttypes.loc * Parsetree.module_type option) list *
  Parsetree.module_expr

--- a/src/napkin_printer.ml
+++ b/src/napkin_printer.ml
@@ -2411,8 +2411,9 @@ and printIfChain pexp_attributes ifs elseExpr cmtTbl =
       printExpressionBlock ~braces:true expr cmtTbl;
     ]
   in
+  let attrs = ParsetreeViewer.filterFragileMatchAttributes pexp_attributes in
   Doc.concat [
-    printAttributes pexp_attributes cmtTbl;
+    printAttributes attrs cmtTbl;
     ifDocs;
     elseDoc;
   ]
@@ -3072,6 +3073,7 @@ and printExpression (e : Parsetree.expression) cmtTbl =
   | Pexp_newtype _
   | Pexp_setfield _
   | Pexp_ifthenelse _ -> true
+  | Pexp_match _ when ParsetreeViewer.isIfLetExpr e -> true
   | Pexp_construct _ when ParsetreeViewer.hasJsxAttribute e.pexp_attributes -> true
   | _ -> false
   in

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -504,35 +504,36 @@ let ifElseIfThen =
   then f ()
   else if foo = bar2 then f1 () else if foo = bar3 then f2 () else f3 ()
 let x = (if true then 1 else 2) + (if false then 2 else 3)
-;;((match foo () with | Some x -> doSomethingWithX x | _ -> ())[@ns.iflet ])
+;;((match foo () with | Some x -> doSomethingWithX x | _ -> ())
+  [@ns.iflet ][@warning \\"-4\\"])
 ;;((match foo () with
     | Some x -> doSomethingWithX x
-    | _ -> doSomethingElse ())[@ns.iflet ])
+    | _ -> doSomethingElse ())[@ns.iflet ][@warning \\"-4\\"])
 ;;((match foo () with
     | Some x -> doSomethingWithX x
     | _ ->
         (((match bar () with
            | Some y -> doSomethingWithY y
            | _ -> doSomethingElse ()))
-        [@ns.iflet ]))[@ns.iflet ])
+        [@ns.iflet ][@warning \\"-4\\"]))[@ns.iflet ][@warning \\"-4\\"])
 ;;((match foo () with
     | Some x -> doSomethingWithX x
     | _ -> if n > 10 then doSomethingWithForN () else doSomethingElse ())
-  [@ns.iflet ])
+  [@ns.iflet ][@warning \\"-4\\"])
 ;;if n > 10
   then doSomethingWithForN ()
   else
     (((match foo () with
        | Some x -> doSomethingWithX x
        | _ -> doSomethingElse ()))
-    [@ns.iflet ])
+    [@ns.iflet ][@warning \\"-4\\"])
 ;;if n > 10
   then ((doSomethingWithForN ())[@aa ])
   else
     (((match ((foo ())[@dd ]) with
        | ((Some ((x)[@cc ]))[@bb ]) -> ((doSomethingWithY x)[@ee ])
        | _ -> ((doSomethingElse ())[@ff ])))
-    [@ns.iflet ])
+    [@ns.iflet ][@warning \\"-4\\"])
 ;;((match foo () with
     | Some x -> doSomethingWithX x
     | _ ->
@@ -540,26 +541,27 @@ let x = (if true then 1 else 2) + (if false then 2 else 3)
            | Some y -> doSomethingWithY y
            | _ ->
                (((match baz () with | Some z -> doSomethingWithZ z | _ -> ()))
-               [@ns.iflet ])))
-        [@ns.iflet ]))[@ns.iflet ])
+               [@ns.iflet ][@warning \\"-4\\"])))
+        [@ns.iflet ][@warning \\"-4\\"]))[@ns.iflet ][@warning \\"-4\\"])
 ;;((match foo () with
     | Some (Thing (With { many = Internal [|Components;q|] })) as p ->
         doSomethingWithE e
-    | _ -> ())[@ns.iflet ])
-let a = ((match foo () with | Some x -> x | _ -> 123)[@ns.iflet ])
+    | _ -> ())[@ns.iflet ][@warning \\"-4\\"])
+let a = ((match foo () with | Some x -> x | _ -> 123)
+  [@ns.iflet ][@warning \\"-4\\"])
 let getZ nested =
   ((match nested.origin with
     | Some point -> (((match point.z with | Some z -> z | _ -> 0))
-        [@ns.iflet ])
+        [@ns.iflet ][@warning \\"-4\\"])
     | _ -> 0)
-  [@ns.iflet ])
+  [@ns.iflet ][@warning \\"-4\\"])
 ;;((match foo () with
     | Some (Thing (With { many = Internal [|Components;q|] })) as p ->
         ((((match foo () with
             | Other (Thing (With { many = Internal [|Components;q|] })) as p
                 -> doSomethingElse e
             | _ -> ()))
-         [@ns.iflet ]);
+         [@ns.iflet ][@warning \\"-4\\"]);
          doSomethingWithE e)
     | _ ->
         (((match foo () with
@@ -570,10 +572,13 @@ let getZ nested =
                   | Some (Thing (With { many = Internal [|Components;q|] }))
                       as p -> doSomethingWithE e
                   | _ -> ()))
-               [@ns.iflet ])))
-        [@ns.iflet ]))[@ns.iflet ])
+               [@ns.iflet ][@warning \\"-4\\"])))
+        [@ns.iflet ][@warning \\"-4\\"]))[@ns.iflet ][@warning \\"-4\\"])
 let a =
-  ((if b then ((match foo () with | Some x -> 1 | _ -> 2)[@ns.iflet ]) else 3)
+  ((if b
+    then ((match foo () with | Some x -> 1 | _ -> 2)
+      [@ns.iflet ][@warning \\"-4\\"])
+    else 3)
   [@ns.ternary ])"
 `;
 

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -503,7 +503,78 @@ let ifElseIfThen =
   if foo = bar
   then f ()
   else if foo = bar2 then f1 () else if foo = bar3 then f2 () else f3 ()
-let x = (if true then 1 else 2) + (if false then 2 else 3)"
+let x = (if true then 1 else 2) + (if false then 2 else 3)
+;;((match foo () with | Some x -> doSomethingWithX x | _ -> ())[@ns.iflet ])
+;;((match foo () with
+    | Some x -> doSomethingWithX x
+    | _ -> doSomethingElse ())[@ns.iflet ])
+;;((match foo () with
+    | Some x -> doSomethingWithX x
+    | _ ->
+        (((match bar () with
+           | Some y -> doSomethingWithY y
+           | _ -> doSomethingElse ()))
+        [@ns.iflet ]))[@ns.iflet ])
+;;((match foo () with
+    | Some x -> doSomethingWithX x
+    | _ -> if n > 10 then doSomethingWithForN () else doSomethingElse ())
+  [@ns.iflet ])
+;;if n > 10
+  then doSomethingWithForN ()
+  else
+    (((match foo () with
+       | Some x -> doSomethingWithX x
+       | _ -> doSomethingElse ()))
+    [@ns.iflet ])
+;;if n > 10
+  then ((doSomethingWithForN ())[@aa ])
+  else
+    (((match ((foo ())[@dd ]) with
+       | ((Some ((x)[@cc ]))[@bb ]) -> ((doSomethingWithY x)[@ee ])
+       | _ -> ((doSomethingElse ())[@ff ])))
+    [@ns.iflet ])
+;;((match foo () with
+    | Some x -> doSomethingWithX x
+    | _ ->
+        (((match bar () with
+           | Some y -> doSomethingWithY y
+           | _ ->
+               (((match baz () with | Some z -> doSomethingWithZ z | _ -> ()))
+               [@ns.iflet ])))
+        [@ns.iflet ]))[@ns.iflet ])
+;;((match foo () with
+    | Some (Thing (With { many = Internal [|Components;q|] })) as p ->
+        doSomethingWithE e
+    | _ -> ())[@ns.iflet ])
+let a = ((match foo () with | Some x -> x | _ -> 123)[@ns.iflet ])
+let getZ nested =
+  ((match nested.origin with
+    | Some point -> (((match point.z with | Some z -> z | _ -> 0))
+        [@ns.iflet ])
+    | _ -> 0)
+  [@ns.iflet ])
+;;((match foo () with
+    | Some (Thing (With { many = Internal [|Components;q|] })) as p ->
+        ((((match foo () with
+            | Other (Thing (With { many = Internal [|Components;q|] })) as p
+                -> doSomethingElse e
+            | _ -> ()))
+         [@ns.iflet ]);
+         doSomethingWithE e)
+    | _ ->
+        (((match foo () with
+           | Some (Thing (With { many = Internal [|Components;q|] })) as p ->
+               doSomethingWithE e
+           | _ ->
+               (((match foo () with
+                  | Some (Thing (With { many = Internal [|Components;q|] }))
+                      as p -> doSomethingWithE e
+                  | _ -> ()))
+               [@ns.iflet ])))
+        [@ns.iflet ]))[@ns.iflet ])
+let a =
+  ((if b then ((match foo () with | Some x -> 1 | _ -> 2)[@ns.iflet ]) else 3)
+  [@ns.ternary ])"
 `;
 
 exports[`infix.js 1`] = `

--- a/tests/parsing/grammar/expressions/if.js
+++ b/tests/parsing/grammar/expressions/if.js
@@ -14,7 +14,7 @@ let ifThenElse = if foo {
    lala
 } else {
   doStuff(x, y, z,)
-} 
+}
 
 let ifElseIfThen =
   if foo == bar {
@@ -28,3 +28,111 @@ let ifElseIfThen =
   }
 
 let x = if true { 1 } else { 2 } + if false { 2 } else { 3 }
+
+// Basic
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+}
+
+// Else branch
+if let Some(x) = foo(){
+  doSomethingWithX(x)
+} else {
+  doSomethingElse()
+}
+
+// Else-if support
+if let Some(x) = foo(){
+  doSomethingWithX(x)
+} else if let Some(y) = bar(){
+  doSomethingWithY(y)
+} else {
+  doSomethingElse()
+}
+
+// Mixed conditions, pattern start
+if let Some(x) = foo(){
+  doSomethingWithX(x)
+} else if n > 10 {
+  doSomethingWithForN()
+} else {
+  doSomethingElse()
+}
+
+// Mixed conditions, condition start
+if n > 10 {
+  doSomethingWithForN()
+} else if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else {
+  doSomethingElse()
+}
+
+// Maintains attrs correctly
+if n > 10 {
+  @aa
+  doSomethingWithForN()
+} else if let @bb Some(@cc x) = @dd foo() {
+  @ee
+  doSomethingWithY(x)
+} else {
+  @ff
+  doSomethingElse()
+}
+
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else if let Some(y) = bar() {
+  doSomethingWithY(y)
+} else if let Some(z) = baz() {
+  doSomethingWithZ(z)
+}
+
+// full destructuring
+if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+}
+
+// Assignment
+let a = if let Some(x) = foo() {
+  x
+} else {
+  123
+}
+
+// Nesting
+let getZ = nested =>
+  if let Some(point) = nested.origin {
+    if let Some(z) = point.z {
+      z
+    } else {
+      0
+    }
+  } else {
+    0
+  }
+
+// Complex nesting
+if let Some(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+  if let Other(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+    doSomethingElse(e)
+  }
+  doSomethingWithE(e)
+} else if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+} else if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+}
+
+// Mixed with ternary
+let a = b ? if let Some(x) = foo() {
+  1
+} else {
+  2
+} : 3

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -2198,6 +2198,195 @@ let x =
 if inclusions[index] = (uid, url) {
   onChange(inclusions)
 }
+
+// Basic
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+}
+
+// Else branch
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else {
+  doSomethingElse()
+}
+
+// Else-if support
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else if let Some(y) = bar() {
+  doSomethingWithY(y)
+} else {
+  doSomethingElse()
+}
+
+// Mixed conditions, pattern start
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else if n > 10 {
+  doSomethingWithForN()
+} else {
+  doSomethingElse()
+}
+
+// Mixed conditions, condition start
+if n > 10 {
+  doSomethingWithForN()
+} else if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else {
+  doSomethingElse()
+}
+
+// Maintains attrs correctly
+if n > 10 {
+  @aa
+  doSomethingWithForN()
+} else if let @bb Some(@cc x) = @dd
+foo() {
+  @ee
+  doSomethingWithY(x)
+} else {
+  @ff
+  doSomethingElse()
+}
+
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else if let Some(y) = bar() {
+  doSomethingWithY(y)
+} else if let Some(z) = baz() {
+  doSomethingWithZ(z)
+}
+
+// full destructuring
+if let Some(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+  doSomethingWithE(e)
+}
+
+// Assignment
+let a = if let Some(x) = foo() {
+  x
+} else {
+  123
+}
+
+// Nesting
+let getZ = nested =>
+  if let Some(point) = nested.origin {
+    if let Some(z) = point.z {
+      z
+    } else {
+      0
+    }
+  } else {
+    0
+  }
+
+// Deep nesting
+let getZ = nested =>
+  if let Some(nested) = nested.a {
+    if let Some(nested) = nested.b {
+      if let Some(nested) = nested.c {
+        if let Some(nested) = nested.d {
+          if let Some(nested) = nested.e {
+            if let Some(nested) = nested.f {
+              if let Some(nested) = nested.g {
+                z
+              } else {
+                0
+              }
+            } else {
+              0
+            }
+          } else if let Some(nested) = nested.g {
+            z
+          } else {
+            0
+          }
+        } else if a {
+          b
+        } else {
+          c
+        }
+      } else {
+        0
+      }
+    } else {
+      0
+    }
+  } else {
+    0
+  }
+
+// Break testing
+if let Some(
+  suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName,
+) = anotherSuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName() {
+  foo()
+}
+
+if let Some(
+  suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName,
+) = anotherSuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongNameanotherSuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName(
+  withSomeArgsThatAreAlsoLarge,
+  withManyArgsThatAreAlsoLarge,
+) {
+  foo()
+}
+
+if let {
+  suuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName,
+  suuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName2,
+  suuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName3,
+} = buildMyRecord() {
+  foo()
+}
+
+// Complex nesting
+if let Some(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+  if let Other(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+    doSomethingElse(e)
+  }
+  doSomethingWithE(e)
+} else if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+} else if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+}
+
+// Ternary
+let a = b
+  ? if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
+  : 3
+
+let a = b
+  ? 1
+  : if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
+
+let a = b
+  ? if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
+  : if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
 "
 `;
 

--- a/tests/printer/expr/if.js
+++ b/tests/printer/expr/if.js
@@ -11,7 +11,7 @@ let name = if true {
 let name = if true {
   user.name
 } else if false {
-  user.lastName 
+  user.lastName
 } else {
   defaultName
 }
@@ -37,3 +37,181 @@ let x = @attr if truth {
 if inclusions[index] = (uid, url) {
   onChange(inclusions)
 }
+
+
+// Basic
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+}
+
+// Else branch
+if let Some(x) = foo(){
+  doSomethingWithX(x)
+} else {
+  doSomethingElse()
+}
+
+// Else-if support
+if let Some(x) = foo(){
+  doSomethingWithX(x)
+} else if let Some(y) = bar(){
+  doSomethingWithY(y)
+} else {
+  doSomethingElse()
+}
+
+// Mixed conditions, pattern start
+if let Some(x) = foo(){
+  doSomethingWithX(x)
+} else if n > 10 {
+  doSomethingWithForN()
+} else {
+  doSomethingElse()
+}
+
+// Mixed conditions, condition start
+if n > 10 {
+  doSomethingWithForN()
+} else if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else {
+  doSomethingElse()
+}
+
+// Maintains attrs correctly
+if n > 10 {
+  @aa
+  doSomethingWithForN()
+} else if let @bb Some(@cc x) = @dd foo() {
+  @ee
+  doSomethingWithY(x)
+} else {
+  @ff
+  doSomethingElse()
+}
+
+if let Some(x) = foo() {
+  doSomethingWithX(x)
+} else if let Some(y) = bar() {
+  doSomethingWithY(y)
+} else if let Some(z) = baz() {
+  doSomethingWithZ(z)
+}
+
+// full destructuring
+if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+}
+
+// Assignment
+let a = if let Some(x) = foo() {
+  x
+} else {
+  123
+}
+
+// Nesting
+let getZ = nested =>
+  if let Some(point) = nested.origin {
+    if let Some(z) = point.z {
+      z
+    } else {
+      0
+    }
+  } else {
+    0
+  }
+
+// Deep nesting
+let getZ = nested =>
+  if let Some(nested) = nested.a {
+    if let Some(nested) = nested.b {
+      if let Some(nested) = nested.c {
+        if let Some(nested) = nested.d {
+          if let Some(nested) = nested.e {
+            if let Some(nested) = nested.f {
+              if let Some(nested) = nested.g {
+                z
+              } else {
+                0
+              }
+            } else {
+              0
+            }
+          } else if let Some(nested) = nested.g {
+            z
+          } else {
+            0
+          }
+        } else {
+          a ? b : c
+        }
+      } else {
+        0
+      }
+    } else {
+      0
+    }
+  } else {
+    0
+  }
+
+// Break testing
+if let Some(suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName) = anotherSuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName() {
+  foo()
+}
+
+if let Some(suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName) = anotherSuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongNameanotherSuuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName(withSomeArgsThatAreAlsoLarge, withManyArgsThatAreAlsoLarge) {
+  foo()
+}
+
+if let { suuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName, suuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName2, suuuuuuuuuuuuuuuuuuuuuuuuuuuperLongName3 } = buildMyRecord() {
+  foo()
+}
+
+// Complex nesting
+if let Some(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+  if let Other(Thing(With({many: Internal([Components, q])}))) as p = foo() {
+    doSomethingElse(e)
+  }
+  doSomethingWithE(e)
+} else if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+} else if let Some(Thing(With({
+  many: Internal([Components, q]),
+}))) as p = foo() {
+  doSomethingWithE(e)
+}
+
+// Ternary
+let a = b
+  ? if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
+  : 3
+
+let a = b
+  ? 1
+  : if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
+
+let a = b
+  ? if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }
+  : if let Some(x) = foo() {
+      1
+    } else {
+      2
+    }


### PR DESCRIPTION
`if let` brings pattern matching to `if`
---------------------------------------
`if let PAT = EXPR { BODY }`

The motivation for having any construct at all for this is to simplify the cases that today call for
a switch statement with a single non-trivial case. This is predominately used for unwrapping
`option<'t>` values, but can be used elsewhere.

Before:
```reason
switch(optVal) {
    | Some(x) => doSomethingWith(x)
    | _ => ()
}
```

After:
```reason
if let Some(x) = optVal {
    doSomethingWith(x)
}
```

Complex example:
```reason
if let Some(x) = optVal when x > 10 {
    doSomethingWith(x)
} else if let Theme({color: Red | Blue, emoji}) = getTheme() {
    doSomething()
} else {
    doSomethingElse()
}
```

There are >500 occurrences in FB of `| _ => ()` where this form would be more appropriate

This is syntax sugar only, it's implemented similar to `ns.ternary` so that that it should be stable across parsing and printing


Prior Art
---------
https://github.com/facebook/reason/issues/1301

* Rust - https://github.com/rust-lang/rfcs/pull/160. The same justifications apply here

* Swift `if case x {}` and `if var = foo()` (for reference types)

* Clojure https://clojuredocs.org/clojure.core/if-let