### PR TITLE
Default parsing of template literals to preserve unicode.

### DIFF
--- a/src/napkin_ast_conversion.ml
+++ b/src/napkin_ast_conversion.ml
@@ -349,7 +349,12 @@ let normalize =
         let s = Parsetree.Pconst_string (raw, None) in
         {expr with pexp_desc = Pexp_constant s}
       | Pexp_constant (Pconst_string (txt, tag)) ->
-        let s = Parsetree.Pconst_string ((escapeTemplateLiteral txt), tag) in
+        let newTag = match tag with
+        (* transform {|abc|} into {js|abc|js}, we want to preserve unicode by default *)
+        | Some "" -> Some "js"
+        | tag -> tag
+        in
+        let s = Parsetree.Pconst_string ((escapeTemplateLiteral txt), newTag) in
         {expr with
           pexp_attributes = mapper.attributes mapper expr.pexp_attributes;
           pexp_desc = Pexp_constant s

--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -2107,7 +2107,7 @@ and parseBinaryExpr ?(context=OrdinaryExpr) ?a p prec =
     (* | _ -> false *)
   (* ) *)
 
-and parseTemplateExpr ?(prefix="") p =
+and parseTemplateExpr ?(prefix="js") p =
   let hiddenOperator =
     let op = Location.mknoloc (Longident.Lident "^") in
     Ast_helper.Exp.ident op

--- a/src/napkin_printer.ml
+++ b/src/napkin_printer.ml
@@ -398,7 +398,7 @@ let printConstant c = match c with
     Doc.text ("\"" ^ txt ^ "\"")
   | Pconst_string (txt, Some prefix) ->
     Doc.concat [
-      if prefix = "" then Doc.nil else Doc.text prefix;
+      if prefix = "js" then Doc.nil else Doc.text prefix;
       Doc.text ("`" ^ txt ^ "`")
     ]
   | Pconst_float (s, _) -> Doc.text s
@@ -3223,7 +3223,7 @@ and printSetFieldExpr attrs lhs longidentLoc rhs loc cmtTbl =
   printComments doc cmtTbl loc
 
 and printTemplateLiteral expr cmtTbl =
-  let tag = ref "j" in
+  let tag = ref "js" in
   let rec walkExpr expr =
     let open Parsetree in
     match expr.pexp_desc with
@@ -3243,7 +3243,7 @@ and printTemplateLiteral expr cmtTbl =
   in
   let content = walkExpr expr in
   Doc.concat [
-    if !tag = "j" then Doc.nil else Doc.text !tag;
+    if !tag = "js" then Doc.nil else Doc.text !tag;
     Doc.text "`";
     content;
     Doc.text "`"

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -373,7 +373,7 @@ It seems that this record field mutation misses an expression
 
 exports[`taggedTemplateLiterals.js 1`] = `
 "=====Parsetree==========================================
-;;{|null|}
+;;{js|null|js}
 =====Errors=============================================
 
 File \\"/syntax/tests/parsing/errors/expressions/taggedTemplateLiterals.js\\", line 1, characters 0-5:

--- a/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
@@ -66,13 +66,13 @@ exports[`gh16B.ns 1`] = `
 open Ws
 let wss = Server.make { port = 82 }
 let address = wss |. Server.address
-let log msg = Js.log ({|> Server: |} ^ msg)
+let log msg = Js.log ({js|> Server: |js} ^ msg)
 ;;log
-    (((((({|Running on: |} ^ address.address) ^ {|:|}) ^
+    (((((({js|Running on: |js} ^ address.address) ^ {js|:|js}) ^
           (address.port |. string_of_int))
-         ^ {| (|})
+         ^ {js| (|js})
         ^ address.family)
-       ^ {|)|})
+       ^ {js|)|js})
 module ClientSet =
   struct
     module T =

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -227,7 +227,7 @@ let reifyStyle (type a) (x : 'a) =
          external canvasGradient : constructor = \\"CanvasGradient\\"[@@bs.val ]
          external canvasPattern : constructor = \\"CanvasPattern\\"[@@bs.val ]
          let instanceOf =
-           ([%bs.raw {|function(x,y) {return +(x instanceof y)}|}] : 
+           ([%bs.raw {js|function(x,y) {return +(x instanceof y)}|js}] : 
            'a -> constructor -> bool)
        end in
        ((if (Js.typeof x) = \\"string\\"
@@ -307,11 +307,11 @@ let y = false
 let txt = \\"a string\\"
 let txtWithEscapedChar = \\"foo\\\\nbar\\"
 let number = 1
-let template = {|amazing
+let template = {js|amazing
   multine
   template
      string
-|}
+|js}
 let complexNumber = 1.6
 let x = 0b0000_0001
 let int32 = 42l
@@ -376,28 +376,29 @@ let u = ()"
 `;
 
 exports[`es6template.js 1`] = `
-"let s = {|foo|}
-let s = {|multi
+"let s = {js|foo|js}
+let s = {js|multi
   line
 
 string
-|}
+|js}
 let s = foo
-let s = {|before|} ^ foo
-let s = {|before |} ^ foo
-let s = {|before  |} ^ foo
-let s = foo ^ {|after|}
-let s = foo ^ {| after|}
-let s = foo ^ {|  after|}
+let s = {js|before|js} ^ foo
+let s = {js|before |js} ^ foo
+let s = {js|before  |js} ^ foo
+let s = foo ^ {js|after|js}
+let s = foo ^ {js| after|js}
+let s = foo ^ {js|  after|js}
 let s = foo ^ bar
 let s = (foo ^ bar) ^ baz
-let s = (foo ^ {| |}) ^ bar
-let s = (((foo ^ {| |}) ^ bar) ^ {| |}) ^ baz
-let s = ((({| before |} ^ foo) ^ {| |}) ^ bar) ^ {| after |}
+let s = (foo ^ {js| |js}) ^ bar
+let s = (((foo ^ {js| |js}) ^ bar) ^ {js| |js}) ^ baz
+let s = ((({js| before |js} ^ foo) ^ {js| |js}) ^ bar) ^ {js| after |js}
 let s =
-  ((((({|before |} ^ foo) ^ {| middle |}) ^ bar) ^ {| |}) ^ baz) ^ {| wow |}
+  ((((({js|before |js} ^ foo) ^ {js| middle |js}) ^ bar) ^ {js| |js}) ^ baz)
+    ^ {js| wow |js}
 let s =
-  {|
+  {js|
   multiline
 
   es6
@@ -409,11 +410,11 @@ let s =
   so convenient
 
   :)
-|}
-let s = {|$dollar without $braces $interpolation|}
+|js}
+let s = {js|$dollar without $braces $interpolation|js}
 let s = {json|null|json}
-let x = {|foo\`bar$\\\\foo|}
-let x = ((({|foo\`bar$\\\\foo|} ^ a) ^ {| \` |}) ^ b) ^ {| \` xx|}"
+let x = {js|foo\`bar$\\\\foo|js}
+let x = ((({js|foo\`bar$\\\\foo|js} ^ a) ^ {js| \` |js}) ^ b) ^ {js| \` xx|js}"
 `;
 
 exports[`extension.js 1`] = `
@@ -1075,7 +1076,7 @@ let _ =
 let _ =
   ((div
       ~children:[(((let left = limit |. Int.toString in
-                    (left ^ {| characters left|}) |. React.string))
+                    (left ^ {js| characters left|js}) |. React.string))
                 [@ns.braces ])] ())
   [@JSX ])
 let _ =
@@ -1149,7 +1150,7 @@ let truth = false
 let constructor = None
 let longidentConstructor = Option.None
 let txt = \\"a string\\"
-let otherTxt = {|foo bar |} ^ txt
+let otherTxt = {js|foo bar |js} ^ txt
 let ident = myIdent
 let aList = [1; 2]
 let anArray = [|1;2|]

--- a/tests/parsing/infiniteLoops/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/infiniteLoops/__snapshots__/parse.spec.js.snap
@@ -209,7 +209,7 @@ include
           mutable size: int ;
           mutable root: 'value node option ;
           compare: [ [%napkinscript.typehole ]] Js.Internal.fn }
-        ;;{|Arity_2('value, 'value)], int),
+        ;;{js|Arity_2('value, 'value)], int),
                       };
                     }: {
 
@@ -220,7 +220,7 @@ include
             (
               ~size: int,
               ~root: option(node('value)),
-              ~compare: Js.Internal.fn([ | |}
+              ~compare: Js.Internal.fn([ | |js}
         ;;Arity_2 (value, value)
         ;;int
         ;;(t value) = \\"\\"
@@ -256,12 +256,12 @@ include
         ;;[|((1)[@internal.arity ])|]
         external compare :
           'value t -> [ [%napkinscript.typehole ]] Js.Internal.fn
-        ;;{|Arity_2('value, 'value)], int) =
+        ;;{js|Arity_2('value, 'value)], int) =
             \\"\\"
             \\"BS:6.0.1\\\\132\\\\149\\\\166\\\\190\\\\000\\\\000\\\\000\\\\019\\\\000\\\\000\\\\000\\\\007\\\\000\\\\000\\\\000\\\\020\\\\000\\\\000\\\\000\\\\019\\\\176\\\\160\\\\160A\\\\145@@A\\\\152\\\\160'compare@\\";
           [@internal.arity 1]
           external compareGet:
-            t('value) => Js.Internal.fn([ | |}
+            t('value) => Js.Internal.fn([ | |js}
         ;;Arity_2 (value, value)
         ;;int
         ;;\\"\\"

--- a/tests/parsing/recovery/string/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/recovery/string/__snapshots__/parse.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`eof.js 1`] = `"let x = \\"eof here\\""`;
 
-exports[`es6template.js 1`] = `"let x = ({|this contains |} ^ foo) ^ {|, missing closin|}"`;
+exports[`es6template.js 1`] = `"let x = ({js|this contains |js} ^ foo) ^ {js|, missing closin|js}"`;
 
 exports[`unclosed.js 1`] = `
 "let x = \\"unclosed\\"


### PR DESCRIPTION
By parsing \`foo bar\` as `{js|foo|js}`, we get unicode for free in the javascript output.
For future conversion,`{||}` will be converted in `{js||js}` once upfront.

Fixes https://github.com/BuckleScript/syntax/issues/13