### PR TITLE
Make `catch` not a keyword, but just an identifier.

### DIFF
--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -2948,7 +2948,7 @@ and parseTryExpression p =
   let startPos = p.Parser.startPos in
   Parser.expect Try p;
   let expr = parseExpr ~context:WhenExpr p in
-  Parser.expect (Lident "catch") p;
+  Parser.expect Napkin_token.catch p;
   Parser.expect Lbrace p;
   let cases = parsePatternMatching p in
   Parser.expect Rbrace p;

--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -2948,7 +2948,7 @@ and parseTryExpression p =
   let startPos = p.Parser.startPos in
   Parser.expect Try p;
   let expr = parseExpr ~context:WhenExpr p in
-  Parser.expect Catch p;
+  Parser.expect (Lident "catch") p;
   Parser.expect Lbrace p;
   let cases = parsePatternMatching p in
   Parser.expect Rbrace p;

--- a/src/napkin_token.ml
+++ b/src/napkin_token.ml
@@ -71,7 +71,7 @@ type t =
   | TemplatePart of string
   | Backtick
   | BarGreater
-  | Try | Catch
+  | Try
   | Import
   | Export
 
@@ -161,7 +161,7 @@ let toString = function
   | TemplateTail text -> "TemplateTail(" ^ text ^ ")"
   | Backtick -> "`"
   | BarGreater -> "|>"
-  | Try -> "try" | Catch -> "catch"
+  | Try -> "try"
   | Import -> "import"
   | Export -> "export"
 
@@ -196,7 +196,6 @@ let keywordTable = function
 | "list{" -> List
 | "with" -> With
 | "try" -> Try
-| "catch" -> Catch
 | "import" -> Import
 | "export" -> Export
 | _ -> raise Not_found
@@ -208,7 +207,7 @@ let isKeyword = function
   | Downto | While | Switch | When | External | Typ | Private
   | Mutable | Constraint | Include | Module | Of
   | Land | Lor | List | With
-  | Try | Catch | Import | Export -> true
+  | Try | Import | Export -> true
   | _ -> false
 
 let lookupKeyword str =

--- a/src/napkin_token.ml
+++ b/src/napkin_token.ml
@@ -93,8 +93,8 @@ let toString = function
   | True -> "true" | False -> "false"
   | Character c -> "character '" ^ (Char.escaped c) ^ "'"
   | String s -> "string \"" ^ s ^ "\""
-  | Lident str -> "lident \"" ^ str ^ "\""
-  | Uident str -> "uident \"" ^ str ^ "\""
+  | Lident str -> str
+  | Uident str -> str
   | Dot -> "." | DotDot -> ".." | DotDotDot -> "..."
   | Int {i} -> "int " ^ i
   | Float {f} -> "Float: " ^ f
@@ -220,3 +220,5 @@ let lookupKeyword str =
 let isKeywordTxt str =
   try let _ = keywordTable str in true with
   | Not_found -> false
+
+let catch = Lident "catch"

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -398,11 +398,11 @@ File \\"/syntax/tests/parsing/errors/expressions/try.js\\", line 2, characters 3
 
 1 │    let parsedPayload =
 [31m2[0m │      try (Js.Json.parseExn(response)) {          
-                                          [31m^^^^^[0m
+                                          [31m^^^^^^^^^^^^^^[0m
 3 │      | _ => Js.Json.null
 4 │      }
 
-Did you forget a \`catch\` here? 
+Did you forget a \`lident \\"catch\\"\` here? 
 
 
 

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -398,11 +398,11 @@ File \\"/syntax/tests/parsing/errors/expressions/try.js\\", line 2, characters 3
 
 1 │    let parsedPayload =
 [31m2[0m │      try (Js.Json.parseExn(response)) {          
-                                          [31m^^^^^^^^^^^^^^[0m
+                                          [31m^^^^^[0m
 3 │      | _ => Js.Json.null
 4 │      }
 
-Did you forget a \`lident \\"catch\\"\` here? 
+Did you forget a \`catch\` here? 
 
 
 

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -557,6 +557,10 @@ switch x {
     // c7
   } => ()
 }
+
+let catch = 34
+
+let promiseCatch = x => Js.Promise.catch(x)
 "
 `;
 

--- a/tests/printer/comments/blockExpr.res
+++ b/tests/printer/comments/blockExpr.res
@@ -511,3 +511,7 @@ switch x {
 
  } => ()
 }
+
+let catch = 34
+
+let promiseCatch = x => Js.Promise.catch(x)


### PR DESCRIPTION
Fixes https://github.com/BuckleScript/syntax/issues/28