### PR TITLE
Expose Napkin_diagnostic's toString and explain function

### DIFF
--- a/src/napkin_diagnostics.mli
+++ b/src/napkin_diagnostics.mli
@@ -10,6 +10,9 @@ val parseReportStyle: string -> reportStyle
 val getStartPos: t -> Lexing.position [@@live] (* for playground *)
 val getEndPos: t -> Lexing.position [@@live] (* for playground *)
 
+val toString: t -> string -> string (* for playground *)
+val explain: t -> string (* for playground *)
+
 val unexpected: Token.t -> (Grammar.t * Lexing.position) list -> category
 val expected:  ?grammar:Grammar.t -> Lexing.position -> Token.t -> category
 val uident: Token.t -> category


### PR DESCRIPTION
Exposes the Diagnostic `toString` and `explain` function as public API.

## Why?

1) The playground needs a way to transform a single `Diagnostic.t` into a pretty report string (right now I can only stringify a list of `Diagnostic.t` with `stringOfReport`)
2) The playground needs a small msg string for hover message display (basically only the thing `explain` returns)