### PR TITLE
Prevent race conditions in Reason -> Res printing.

### DIFF
--- a/.depend
+++ b/.depend
@@ -22,8 +22,8 @@ src/napkin_diagnostics.cmi : src/napkin_token.cmx src/napkin_grammar.cmx
 src/napkin_doc.cmx : src/napkin_minibuffer.cmx src/napkin_doc.cmi
 src/napkin_doc.cmi :
 src/napkin_driver.cmx : src/napkin_printer.cmx src/napkin_parser.cmx \
-    src/napkin_diagnostics.cmx src/napkin_core.cmx src/napkin_comment.cmx \
-    src/napkin_driver.cmi
+    src/napkin_io.cmx src/napkin_diagnostics.cmx src/napkin_core.cmx \
+    src/napkin_comment.cmx src/napkin_driver.cmi
 src/napkin_driver.cmi : src/napkin_diagnostics.cmi src/napkin_comment.cmi
 src/napkin_grammar.cmx : src/napkin_token.cmx
 src/napkin_io.cmx : src/napkin_io.cmi
@@ -34,14 +34,15 @@ src/napkin_main.cmx : src/napkin_reason_binary_driver.cmx \
     src/napkin_binary_driver.cmx src/napkin_ast_debugger.cmx
 src/napkin_minibuffer.cmx : src/napkin_minibuffer.cmi
 src/napkin_minibuffer.cmi :
-src/napkin_ml_parser_driver.cmx : src/napkin_driver.cmx \
+src/napkin_ml_parser_driver.cmx : src/napkin_io.cmx src/napkin_driver.cmx \
     src/napkin_comment.cmx src/napkin_ast_conversion.cmx \
     src/napkin_ml_parser_driver.cmi
 src/napkin_ml_parser_driver.cmi : src/napkin_driver.cmi \
     src/napkin_comment.cmi
 src/napkin_multi_printer.cmx : src/napkin_reason_binary_driver.cmx \
-    src/napkin_printer.cmx src/napkin_driver.cmx src/napkin_diagnostics.cmx \
-    src/napkin_multi_printer.cmi
+    src/napkin_printer.cmx src/napkin_ml_parser_driver.cmx src/napkin_io.cmx \
+    src/napkin_driver.cmx src/napkin_diagnostics.cmx \
+    src/napkin_ast_conversion.cmx src/napkin_multi_printer.cmi
 src/napkin_multi_printer.cmi :
 src/napkin_outcome_printer.cmx : src/napkin_doc.cmx \
     src/napkin_outcome_printer.cmi
@@ -67,7 +68,7 @@ src/napkin_reason_binary_driver.cmx : src/napkin_scanner.cmx \
     src/napkin_io.cmx src/napkin_driver.cmx src/napkin_comment.cmx \
     src/napkin_ast_conversion.cmx src/napkin_reason_binary_driver.cmi
 src/napkin_reason_binary_driver.cmi : src/napkin_token.cmx \
-    src/napkin_driver.cmi src/napkin_comment.cmi
+    src/napkin_driver.cmi
 src/napkin_reporting.cmx : src/napkin_token.cmx src/napkin_grammar.cmx
 src/napkin_scanner.cmx : src/napkin_token.cmx src/napkin_diagnostics.cmx \
     src/napkin_comment.cmx src/napkin_character_codes.cmx \

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ FILES = \
 	src/napkin_reason_binary_driver.cmx \
 	src/napkin_binary_driver.cmx \
 	src/napkin_ast_debugger.cmx \
-	src/napkin_outcome_printer.cmx \
-	src/napkin_multi_printer.cmx
+	src/napkin_outcome_printer.cmx
 
 .DEFAULT_GOAL := build-native
 build-native: lib/refmt.exe $(FILES) src/napkin_main.cmx
@@ -62,7 +61,7 @@ benchmarks/refmt_main3b.cmx: benchmarks/refmt_main3b.ml
 	$(OCAMLOPT) -c -O2 -I +compiler-libs ocamlcommon.cmxa benchmarks/refmt_main3b.ml
 
 lib/test.exe: tests/napkin_test.cmx
-	$(OCAMLOPT) $(OCAMLFLAGS) -O2 -o ./lib/test.exe -bin-annot -I +compiler-libs ocamlcommon.cmxa -I src $(FILES) tests/napkin_test.ml
+	$(OCAMLOPT) $(OCAMLFLAGS) -O2 -o ./lib/test.exe -bin-annot -I +compiler-libs ocamlcommon.cmxa unix.cmxa -I src $(FILES) src/napkin_multi_printer.cmx tests/napkin_test.ml
 
 test: build-native lib/test.exe
 	./node_modules/.bin/jest

--- a/src/napkin_io.ml
+++ b/src/napkin_io.ml
@@ -31,9 +31,3 @@ let readStdin () =
     )
   in
   loop ()
-
-let writeFile ~filename ~content =
-  let chan = open_out_bin filename in
-  output_string chan content;
-  close_out chan
-[@@raises Sys_error]

--- a/src/napkin_io.mli
+++ b/src/napkin_io.mli
@@ -5,6 +5,3 @@ val readFile: filename: string -> string
 
 (* read the contents of stdin into a string*)
 val readStdin: unit -> string
-
-(* writes "content" into file with name "filename" *)
-val writeFile: filename: string -> content: string -> unit

--- a/src/napkin_multi_printer.ml
+++ b/src/napkin_multi_printer.ml
@@ -54,64 +54,60 @@ let printMl ~isInterface ~filename =
       parseResult.parsetree
 
 (* How does printing Reason to Res work?
- * -> open a tempfile
- * -> write the source code found in "filename" into the tempfile
- * -> run refmt in-place in binary mode on the tempfile,
- *    mutates contents tempfile with marshalled AST.j
- * -> read the marshalled ast (from the binary output in the tempfile)
+ * -> Run refmt in parallel with the program,
+ *    the standard input and standard output of the refmt command are redirected
+ *    to pipes connected to the two returned channels
+ * -> Read the source code of "filename"
+ * -> Write the source code to output channel (i.e. the input of refmt)
+ * -> Read the marshalled ast from the input channel (i.e. the output of refmt)
  * -> re-read the original "filename" and extract string + comment data
  * -> put the comment- and string data back into the unmarshalled parsetree
+ * -> normalize the ast to conform to the napkin printer
  * -> pretty print to res
  * -> take a deep breath and exhale slowly *)
 let printReason ~refmtPath ~isInterface ~filename =
-  (* open a tempfile *)
-  let (tempFilename, chan) =
-    Filename.open_temp_file "refmt" (if isInterface then ".rei" else ".re") in
-  close_out chan;
-  (* write the source code found in "filename" into the tempfile *)
-  IO.writeFile ~filename:tempFilename ~content:(IO.readFile ~filename);
-  let cmd = Printf.sprintf "%s --print=binary --in-place --interface=%b %s" refmtPath isInterface tempFilename in
-  (* run refmt in-place in binary mode on the tempfile *)
-  ignore (Sys.command cmd);
-  let result =
-    if isInterface then
-      let parseResult =
-        (* read the marshalled ast (from the binary output in the tempfile) *)
-        Napkin_reason_binary_driver.parsingEngine.parseInterface ~forPrinter:true ~filename:tempFilename in
-      (* re-read the original "filename" and extract string + comment data *)
-      let (comments, stringData) = Napkin_reason_binary_driver.extractConcreteSyntax filename in
+  (* Run refmt in parallel with the program *)
+  let refmtCmd = Printf.sprintf "%s --print=binary --interface=%b" refmtPath isInterface in
+  let (refmtOutput, refmtInput) = Unix.open_process refmtCmd in
+  (* Read the source code of "filename" *)
+  let source = IO.readFile ~filename in
+  (* Write the source code to output channel (i.e. the input of refmt) *)
+  output_string refmtInput source;
+  close_out refmtInput;
+  (* Read the marshalled ast from the input channel (i.e. the output of refmt) *)
+  let magic = if isInterface then Config.ast_intf_magic_number else Config.ast_impl_magic_number in
+  ignore ((really_input_string [@doesNotRaise]) refmtOutput (String.length magic));
+  ignore (input_value refmtOutput);
+  let ast = input_value refmtOutput in
+  close_in refmtOutput;
+  (* re-read the original "filename" and extract string + comment data *)
+  let (comments, stringData) = Napkin_reason_binary_driver.extractConcreteSyntax filename in
+  if isInterface then
+    let ast = ast
       (* put the comment- and string data back into the unmarshalled parsetree *)
-      let parseResult = {
-        parseResult with
-        parsetree =
-          parseResult.parsetree |> Napkin_ast_conversion.replaceStringLiteralSignature stringData;
-        comments = comments;
-      } in
-      (* pretty print to res *)
-      Napkin_printer.printInterface
-        ~width:defaultPrintWidth
-        ~comments:parseResult.comments
-        parseResult.parsetree
-    else
-      let parseResult =
-        (* read the marshalled ast (from the binary output in the tempfile) *)
-        Napkin_reason_binary_driver.parsingEngine.parseImplementation ~forPrinter:true ~filename:tempFilename in
-      let (comments, stringData) = Napkin_reason_binary_driver.extractConcreteSyntax filename in
+      |> Napkin_ast_conversion.replaceStringLiteralSignature stringData
+      (* normalize the ast to conform to the napkin printer *)
+      |> Napkin_ast_conversion.normalizeReasonAritySignature ~forPrinter:true
+      |> Napkin_ast_conversion.signature
+    in
+    (* pretty print to res *)
+    Napkin_printer.printInterface
+      ~width:defaultPrintWidth
+      ~comments:comments
+      ast
+  else
+    let ast = ast
       (* put the comment- and string data back into the unmarshalled parsetree *)
-      let parseResult = {
-        parseResult with
-        parsetree =
-          parseResult.parsetree |> Napkin_ast_conversion.replaceStringLiteralStructure stringData;
-        comments = comments;
-      } in
-      (* pretty print to res *)
-      Napkin_printer.printImplementation
-        ~width:defaultPrintWidth
-        ~comments:parseResult.comments
-        parseResult.parsetree
-  in
-  Sys.remove tempFilename;
-  result
+      |> Napkin_ast_conversion.replaceStringLiteralStructure stringData
+      (* normalize the ast to conform to the napkin printer *)
+      |> Napkin_ast_conversion.normalizeReasonArityStructure ~forPrinter:true
+      |> Napkin_ast_conversion.structure
+    in
+    (* pretty print to res *)
+    Napkin_printer.printImplementation
+      ~width:defaultPrintWidth
+      ~comments:comments
+      ast
 [@@raises Sys_error]
 
 (* print the given file named input to from "language" to res, general interface exposed by the compiler *)


### PR DESCRIPTION
Opening a temp file of the same name is gonna get into race conditions.
For conversion, some things might be running in parallel.
No temp file race. It's not even certain that the file will be written
to before we read it back. You don't want these issues to creep up
sometime during conversion and being undebuggable.