### PR TITLE
Infrastructure for outcome printer tests

### DIFF
--- a/.depend
+++ b/.depend
@@ -75,4 +75,5 @@ src/napkin_scanner.cmx : src/napkin_token.cmx src/napkin_diagnostics.cmx \
     src/napkin_scanner.cmi
 src/napkin_scanner.cmi : src/napkin_token.cmx src/napkin_diagnostics.cmi
 src/napkin_token.cmx : src/napkin_comment.cmx src/napkin_character_codes.cmx
-tests/napkin_test.cmx : src/napkin_multi_printer.cmx
+tests/napkin_test.cmx : src/napkin_outcome_printer.cmx \
+    src/napkin_multi_printer.cmx src/napkin_io.cmx src/napkin_driver.cmx

--- a/src/napkin_io.ml
+++ b/src/napkin_io.ml
@@ -32,8 +32,8 @@ let readStdin () =
   in
   loop ()
 
-let writeFile ~filename ~content =
+let writeFile ~filename ~contents:txt =
   let chan = open_out_bin filename in
-  output_string chan content;
+  output_string chan txt;
   close_out chan
 [@@raises Sys_error]

--- a/src/napkin_io.mli
+++ b/src/napkin_io.mli
@@ -7,4 +7,4 @@ val readFile: filename: string -> string
 val readStdin: unit -> string
 
 (* writes "content" into file with name "filename" *)
-val writeFile: filename: string -> content: string -> unit
+val writeFile: filename: string -> contents: string -> unit

--- a/src/napkin_multi_printer.ml
+++ b/src/napkin_multi_printer.ml
@@ -72,7 +72,7 @@ let printReason ~refmtPath ~isInterface ~filename =
     Filename.open_temp_file "refmt" (if isInterface then ".rei" else ".re") in
   close_out chan;
   (* Write the source code found in "filename" into the tempfile *)
-  IO.writeFile ~filename:tempFilename ~content:(IO.readFile ~filename);
+  IO.writeFile ~filename:tempFilename ~contents:(IO.readFile ~filename);
   let cmd = Printf.sprintf "%s --print=binary --in-place --interface=%b %s" refmtPath isInterface tempFilename in
   (* run refmt in-place in binary mode on the tempfile *)
   ignore (Sys.command cmd);

--- a/src/napkin_outcome_printer.ml
+++ b/src/napkin_outcome_printer.ml
@@ -32,7 +32,7 @@
        );
      done;
      Buffer.contents b
- 
+
    (* let rec print_ident fmt ident = match ident with
      | Outcometree.Oide_ident s -> Format.pp_print_string fmt s
      | Oide_dot (id, s) ->
@@ -44,7 +44,7 @@
        Format.pp_print_char fmt '(';
        print_ident fmt id2;
        Format.pp_print_char fmt ')' *)
- 
+
      let rec printOutIdentDoc (ident : Outcometree.out_ident) =
        match ident with
        | Oide_ident s -> Doc.text s
@@ -59,13 +59,13 @@
            printOutIdentDoc arg;
            Doc.rparen;
          ]
- 
+
    let printOutAttributeDoc (outAttribute: Outcometree.out_attribute) =
      Doc.concat [
        Doc.text "@";
        Doc.text outAttribute.oattr_name;
      ]
- 
+
    let printOutAttributesDoc (attrs: Outcometree.out_attribute list) =
      match attrs with
      | [] -> Doc.nil
@@ -76,7 +76,7 @@
          );
          Doc.line;
        ]
- 
+
    let rec collectArrowArgs (outType: Outcometree.out_type) args =
      match outType with
      | Otyp_arrow (label, argType, returnType) ->
@@ -84,7 +84,7 @@
        collectArrowArgs returnType (arg::args)
      | _ as returnType ->
        (List.rev args, returnType)
- 
+
    let rec collectFunctorArgs (outModuleType: Outcometree.out_module_type) args =
      match outModuleType with
      | Omty_functor (lbl, optModType, returnModType) ->
@@ -92,7 +92,7 @@
        collectFunctorArgs returnModType (arg::args)
      | _ ->
        (List.rev args, outModuleType)
- 
+
    let rec printOutTypeDoc (outType: Outcometree.out_type) =
      match outType with
      | Otyp_abstract | Otyp_variant _ (* don't support poly-variants atm *) | Otyp_open -> Doc.nil
@@ -130,13 +130,13 @@
      (* example: Red | Blue | Green | CustomColour(float, float, float) *)
      | Otyp_sum constructors ->
        printOutConstructorsDoc constructors
- 
+
      (* example: {"name": string, "age": int} *)
      | Otyp_constr (
          (Oide_dot ((Oide_ident "Js"), "t")),
          [Otyp_object (fields, rest)]
        ) -> printObjectFields fields rest
- 
+
      (* example: node<root, 'value> *)
      | Otyp_constr (outIdent, args) ->
        let argsDoc = match args with
@@ -235,7 +235,7 @@
        ]
      | Otyp_module (_modName, _stringList, _outTypes) ->
          Doc.nil
- 
+
    and printObjectFields fields rest =
      let dots = match rest with
      | Some non_gen -> Doc.text ((if non_gen then "_" else "") ^ "..")
@@ -263,8 +263,8 @@
          Doc.rbrace;
        ]
      )
- 
- 
+
+
    and printOutConstructorsDoc constructors =
      Doc.group (
        Doc.indent (
@@ -281,7 +281,7 @@
          ]
        )
      )
- 
+
    and printOutConstructorDoc (name, args, gadt) =
        let gadtDoc = match gadt with
        | Some outType ->
@@ -332,7 +332,7 @@
            gadtDoc
          ]
        )
- 
+
    and printRecordDeclRowDoc (name, mut, arg) =
      Doc.group (
        Doc.concat [
@@ -342,7 +342,7 @@
          printOutTypeDoc arg;
        ]
      )
- 
+
    and printRecordDeclarationDoc ~inline rows =
      let content = Doc.concat [
        Doc.lbrace;
@@ -361,18 +361,18 @@
      if not inline then
        Doc.group content
      else content
- 
+
    let printOutType fmt outType =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutTypeDoc outType))
- 
+
    let printTypeParameterDoc (typ, (co, cn)) =
      Doc.concat [
        if not cn then Doc.text "+" else if not co then Doc.text "-" else Doc.nil;
        if typ = "_" then Doc.text "_" else Doc.text ("'" ^ typ)
      ]
- 
- 
+
+
    let rec printOutSigItemDoc (outSigItem : Outcometree.out_sig_item) =
      match outSigItem with
      | Osig_class _ | Osig_class_type _ -> Doc.nil
@@ -540,7 +540,7 @@
          constraints
        ]
      )
- 
+
    and printOutModuleTypeDoc (outModType : Outcometree.out_module_type) =
      match outModType with
      | Omty_abstract -> Doc.nil
@@ -601,7 +601,7 @@
          ]
        )
      | Omty_alias _ident -> Doc.nil
- 
+
    and printOutSignatureDoc (signature : Outcometree.out_sig_item list) =
      let rec loop signature acc =
        match signature with
@@ -639,7 +639,7 @@
        Doc.breakableGroup ~forceBreak:true (
          Doc.join ~sep:Doc.line docs
        )
- 
+
    and printOutExtensionConstructorDoc (outExt : Outcometree.out_extension_constructor) =
      let typeParams = match outExt.oext_type_params with
      | [] -> Doc.nil
@@ -653,7 +653,7 @@
                Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (List.map
                  (fun ty -> Doc.text (if ty = "_" then ty else "'" ^ ty))
                  params
- 
+
                )
              ]
            );
@@ -661,14 +661,14 @@
            Doc.greaterThan;
          ]
        )
- 
+
      in
      Doc.group (
        Doc.concat [
          Doc.text "type ";
          Doc.text outExt.oext_type_name;
          typeParams;
-         Doc.text " +=";
+         Doc.text " += ";
          Doc.line;
          if outExt.oext_private = Asttypes.Private then
            Doc.text "private "
@@ -678,7 +678,7 @@
            (outExt.oext_name, outExt.oext_args, outExt.oext_ret_type)
        ]
      )
- 
+
    and printOutTypeExtensionDoc (typeExtension : Outcometree.out_type_extension) =
      let typeParams = match typeExtension.otyext_params with
      | [] -> Doc.nil
@@ -692,7 +692,7 @@
                Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) (List.map
                  (fun ty -> Doc.text (if ty = "_" then ty else "'" ^ ty))
                  params
- 
+
                )
              ]
            );
@@ -700,14 +700,14 @@
            Doc.greaterThan;
          ]
        )
- 
+
      in
      Doc.group (
        Doc.concat [
          Doc.text "type ";
          Doc.text typeExtension.otyext_name;
          typeParams;
-         Doc.text " +=";
+         Doc.text " += ";
          if typeExtension.otyext_private = Asttypes.Private then
            Doc.text "private "
          else
@@ -715,15 +715,15 @@
          printOutConstructorsDoc typeExtension.otyext_constructors;
        ]
      )
- 
+
    let printOutSigItem fmt outSigItem =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutSigItemDoc outSigItem))
- 
+
    let printOutSignature fmt signature =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutSignatureDoc signature))
- 
+
    let validFloatLexeme s =
      let l = String.length s in
      let rec loop i =
@@ -732,7 +732,7 @@
        | '0' .. '9' | '-' -> loop (i+1)
        | _ -> s
      in loop 0
- 
+
    let floatRepres f =
      match classify_float f with
      | FP_nan -> "nan"
@@ -746,7 +746,7 @@
          if f = (float_of_string [@doesNotRaise]) s2 then s2 else
          Printf.sprintf "%.18g" f
        in validFloatLexeme float_val
- 
+
    let rec printOutValueDoc (outValue : Outcometree.out_value) =
      match outValue with
      | Oval_array outValues ->
@@ -859,7 +859,7 @@
        )
      (* Not supported by NapkinScript *)
      | Oval_variant _ -> Doc.nil
- 
+
    let printOutExceptionDoc exc outValue =
      match exc with
      | Sys.Break -> Doc.text "Interrupted."
@@ -876,7 +876,7 @@
            ]
          )
        )
- 
+
    let printOutPhraseSignature signature =
      let rec loop signature acc =
       match signature with
@@ -922,7 +922,7 @@
       Doc.breakableGroup ~forceBreak:true (
         Doc.join ~sep:Doc.line (loop signature [])
       )
- 
+
    let printOutPhraseDoc (outPhrase : Outcometree.out_phrase) =
      match outPhrase with
      | Ophr_eval (outValue, outType) ->
@@ -943,27 +943,27 @@
      | Ophr_signature signature -> printOutPhraseSignature signature
      | Ophr_exception (exc, outValue) ->
        printOutExceptionDoc exc outValue
- 
+
    let printOutPhrase fmt outPhrase =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutPhraseDoc outPhrase))
- 
+
    let printOutModuleType fmt outModuleType =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutModuleTypeDoc outModuleType))
- 
+
    let printOutTypeExtension fmt typeExtension =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutTypeExtensionDoc typeExtension))
- 
+
    let printOutValue fmt outValue =
      Format.pp_print_string fmt
        (Doc.toString ~width:80 (printOutValueDoc outValue))
- 
-   
 
- 
-   
+
+
+
+
 (* Not supported in Napkin *)
 (* Oprint.out_class_type *)
    let setup  = lazy begin
@@ -974,5 +974,5 @@
     Oprint.out_signature := printOutSignature;
     Oprint.out_type_extension := printOutTypeExtension;
     Oprint.out_phrase := printOutPhrase
-  end  
-     
+  end
+

--- a/tests/napkin_test.ml
+++ b/tests/napkin_test.ml
@@ -162,6 +162,11 @@ module OutcomePrinterTests = struct
       prerr_string "Unknown error while trying to print outcome tree";
       exit 1
 
+  (* `tests/oprint/oprint.res` will be read into memory and typechecked.
+   * The inferred signature (i.e. the type of the module `oprint.res`) will
+   * then be converted to the outcome tree.
+   * The outcome tree is printed to a string
+   * and stored in a snapshot `tests/oprint/oprint.res.snapshot` *)
   let run () =
     let testFileName = "tests/oprint/oprint.res" in
     let printedOutcomeTree =

--- a/tests/napkin_test.ml
+++ b/tests/napkin_test.ml
@@ -23,6 +23,7 @@ module Snapshot = struct
     match diff with
     | Some contents ->
       prerr_string ("❌ snapshot " ^ filename);
+      prerr_newline();
       prerr_string contents;
       exit 1
     | None ->

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -1,1 +1,41 @@
 let name = "Steve"
+let x = 42
+
+let numbersArray = [1, 2, 3, 4, 5]
+let numbersTuple = (1, 2, 3, 4, 5)
+let numbersList = list{1, 2, 3, 4, 5}
+
+let add = (a, b) => a + b
+
+type user = {
+  name: string,
+  age: int,
+}
+
+type user2 = {
+  naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame: string,
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaage: int,
+  emaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaail: string
+}
+
+module Diff = {
+  let string = (s1: string, s2: string) => s1 != s2
+}
+
+module Diff2 = Diff
+
+type rec tree<'value> =
+  | Nil
+  | Node(tree<'value>, 'value, tree<'value>) 
+
+type rec tree2<'value> =
+  | Niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiil2
+  | Noooooooooooooooooooooooooooooooooooode2(tree2<'value>, 'value, tree2<'value>) 
+
+type rec tree3<'value> =
+  | Nil3
+  | Node3({left: tree3<'value>, value: 'value, right: tree3<'value>}) 
+
+type rec tree4<'value> =
+  | Nil4
+  | Node4({leeeeeeeeeeeeeeeeeeeeeeeeeeeeft: tree3<'value>, vaaaaaaaaaaaaaaaaaaaaalue: 'value, riiiiiiiiiiiiiiiiiiiiiiight: tree3<'value>}) 

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -7,6 +7,8 @@ let numbersList = list{1, 2, 3, 4, 5}
 
 let add = (a, b) => a + b
 
+type s = string
+
 type user = {
   name: string,
   age: int,
@@ -28,6 +30,8 @@ type rec tree<'value> =
   | Nil
   | Node(tree<'value>, 'value, tree<'value>) 
 
+type intTree = tree<int>
+
 type rec tree2<'value> =
   | Niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiil2
   | Noooooooooooooooooooooooooooooooooooode2(tree2<'value>, 'value, tree2<'value>) 
@@ -39,3 +43,26 @@ type rec tree3<'value> =
 type rec tree4<'value> =
   | Nil4
   | Node4({leeeeeeeeeeeeeeeeeeeeeeeeeeeeft: tree3<'value>, vaaaaaaaaaaaaaaaaaaaaalue: 'value, riiiiiiiiiiiiiiiiiiiiiiight: tree3<'value>}) 
+
+type color = ..
+
+type color += Blue
+type color += | Red | Green
+
+type color += | Blaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaack | Oraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaange | Reeeeeeeeeeeeeeeeeeeed
+
+module Expr = {
+  type attr = ..
+
+  type attr += private Str(string)
+
+  type attr +=
+    | Int(int)
+    | Float(float)
+}
+
+module User = {
+  type t = {name: string, age: int}
+}
+
+type userT = User.t = {name: string, age: int}

--- a/tests/oprint/oprint.res
+++ b/tests/oprint/oprint.res
@@ -1,0 +1,1 @@
+let name = "Steve"

--- a/tests/oprint/oprint.res.snapshot
+++ b/tests/oprint/oprint.res.snapshot
@@ -4,6 +4,7 @@ let numbersArray: array<int>
 let numbersTuple: (int, int, int, int, int)
 let numbersList: list<int>
 let add: (int, int) => int
+type s = string
 type user = {name: string, age: int}
 type user2 = {
   naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame: string,
@@ -15,6 +16,7 @@ module Diff = {
 }
 module Diff2 = Diff
 type rec tree<'value> =  Nil | Node(tree<'value>, 'value, tree<'value>)
+type intTree = tree<int>
 type rec tree2<'value> =
   | Niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiil2
   | Noooooooooooooooooooooooooooooooooooode2(
@@ -32,3 +34,19 @@ type rec tree4<'value> =
       vaaaaaaaaaaaaaaaaaaaaalue: 'value,
       riiiiiiiiiiiiiiiiiiiiiiight: tree3<'value>,
     })
+type color = ..
+type color +=  Blue
+type color +=  Red | Green
+type color +=
+  | Blaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaack
+  | Oraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaange
+  | Reeeeeeeeeeeeeeeeeeeed
+module Expr = {
+  type attr = ..
+  type attr += private  Str(string)
+  type attr +=  Int(int) | Float(float)
+}
+module User = {
+  type t = {name: string, age: int}
+}
+type userT = User.t = {name: string, age: int}

--- a/tests/oprint/oprint.res.snapshot
+++ b/tests/oprint/oprint.res.snapshot
@@ -1,1 +1,34 @@
 let name: string
+let x: int
+let numbersArray: array<int>
+let numbersTuple: (int, int, int, int, int)
+let numbersList: list<int>
+let add: (int, int) => int
+type user = {name: string, age: int}
+type user2 = {
+  naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame: string,
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaage: int,
+  emaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaail: string,
+}
+module Diff = {
+  let string: (string, string) => bool
+}
+module Diff2 = Diff
+type rec tree<'value> =  Nil | Node(tree<'value>, 'value, tree<'value>)
+type rec tree2<'value> =
+  | Niiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiil2
+  | Noooooooooooooooooooooooooooooooooooode2(
+      tree2<'value>,
+      'value,
+      tree2<'value>,
+    )
+type rec tree3<'value> =
+  | Nil3
+  | Node3({left: tree3<'value>, value: 'value, right: tree3<'value>})
+type rec tree4<'value> =
+  | Nil4
+  | Node4({
+      leeeeeeeeeeeeeeeeeeeeeeeeeeeeft: tree3<'value>,
+      vaaaaaaaaaaaaaaaaaaaaalue: 'value,
+      riiiiiiiiiiiiiiiiiiiiiiight: tree3<'value>,
+    })

--- a/tests/oprint/oprint.res.snapshot
+++ b/tests/oprint/oprint.res.snapshot
@@ -1,0 +1,1 @@
+let name: string

--- a/tests/oprint/test.res
+++ b/tests/oprint/test.res
@@ -1,2 +1,0 @@
-let x = "foobar"
-


### PR DESCRIPTION
Workflow:
1) Add code in `tests/oprint/oprint.res`
2) Run tests through `make test`
3) (optional) update snapshots through `./lib/test.exe -update-snapshot`

How it works:
- `tests/oprint/oprint.res` will be read into memory and typechecked.
- The inferred signature (i.e. the type of the module `oprint.res`) will then be converted to the outcome tree.
- The outcome tree is printed to a string and stored in a snapshot `tests/oprint/oprint.res.snapshot`