### PR TITLE
Make location of variant cases align with the id, not `|`.

### DIFF
--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -4201,12 +4201,11 @@ and parseConstrDeclArgs p =
  and parseTypeConstructorDeclarationWithBar p =
   match p.Parser.token with
   | Bar ->
-    let startPos = p.Parser.startPos in
     Parser.next p;
-    Some (parseTypeConstructorDeclaration ~startPos p)
+    Some (parseTypeConstructorDeclaration p)
   | _ -> None
 
- and parseTypeConstructorDeclaration ~startPos p =
+ and parseTypeConstructorDeclaration p =
    Parser.leaveBreadcrumb p Grammar.ConstructorDeclaration;
    let attrs = parseAttributes p in
    match p.Parser.token with
@@ -4215,8 +4214,7 @@ and parseConstrDeclArgs p =
      Parser.next p;
      let (args, res) = parseConstrDeclArgs p in
      Parser.eatBreadcrumb p;
-     let loc = mkLoc startPos p.prevEndPos in
-     Ast_helper.Type.constructor ~loc ~attrs ?res ~args (Location.mkloc uident uidentLoc)
+     Ast_helper.Type.constructor ~loc:uidentLoc ~attrs ?res ~args (Location.mkloc uident uidentLoc)
    | t ->
     Parser.err p (Diagnostics.uident t);
     Ast_helper.Type.constructor (Location.mknoloc "_")
@@ -4225,9 +4223,8 @@ and parseConstrDeclArgs p =
  and parseTypeConstructorDeclarations ?first p =
   let firstConstrDecl = match first with
   | None ->
-    let startPos = p.Parser.startPos in
     ignore (Parser.optional p Token.Bar);
-    parseTypeConstructorDeclaration ~startPos p
+    parseTypeConstructorDeclaration p
   | Some firstConstrDecl ->
     firstConstrDecl
   in

--- a/tests/printer/comments/__snapshots__/render.spec.js.snap
+++ b/tests/printer/comments/__snapshots__/render.spec.js.snap
@@ -1627,24 +1627,24 @@ exports[`typeDefinition.js 1`] = `
 > = /* before manifest */ string /* after */
 
 /* before */ type /* before name */ t /* after name */ =
-  // above Red
-  | Red // trailing Red
-  // above Blue
-  | Blue // trailing Blue
-  // above Green
-  | Green // trailing Green
+  | // above Red
+  Red // trailing Red
+  | // above Blue
+  Blue // trailing Blue
+  | // above Green
+  Green // trailing Green
 
 /* before */ type /* before name */ t /* after name */ = /* before manifest */ Colour.t /* after manifest */ =
-  // above Red
-  | /* before Red */ Red // trailing Red
-  // above Blue
-  | /* before Blue */ Blue // trailing Blue
-  // above Green
-  | /* before Green */ Green /* trailing Green */ // test
+  | // above Red
+  /* before Red */ Red // trailing Red
+  | // above Blue
+  /* before Blue */ Blue // trailing Blue
+  | // above Green
+  /* before Green */ Green /* trailing Green */ // test
 
 type color =
-  | /* before Red */ Red /* after Red */: /* before gadt */ color /* after gadt */
-  | /* before Blue */ Blue /* after Blue */: /* before gadt */ color /* after gadt */
+  | /* before Red */ Red /* after Red */ /* before gadt */ /* after gadt */: color
+  | /* before Blue */ Blue /* after Blue */: color /* after gadt */
 
 type color =
   /* before constr */ | Rgb(
@@ -1655,17 +1655,23 @@ type color =
 
 type color =
   | /* before constr */ Rgb /* after constructor */(
-      /* before red */ red /* after red */,
-      /* before green */ green /* after green */,
-      /* before blue */ blue /* after blue */,
-    )
+      red,
+      green,
+      blue,
+    ) /* after red */ /* after green */ /* after blue */
+/* before red */
+/* before green */
+/* before blue */
 
 type color =
   | /* before constr */ Rgb /* after constructor */({
-      /* before red */ red /* after red */: /* before typ */ someNumber /* after typ */,
-      /* before green */ green /* after green */: /* before typ */ someNumber /* after typ */,
-      /* before blue */ blue /* after blue */: /* before typ */ someNumber /* after typ */,
-    })
+      red: someNumber,
+      green: someNumber,
+      blue: someNumber,
+    }) /* after red */ /* before typ */ /* after typ */ /* after green */ /* before typ */ /* after typ */ /* after blue */ /* before typ */ /* after typ */
+/* before red */
+/* before green */
+/* before blue */
 
 type color = {
   /* before red */ red /* after red */: /* before typ */ someNumber /* after typ */,

--- a/tests/printer/other/__snapshots__/render.spec.js.snap
+++ b/tests/printer/other/__snapshots__/render.spec.js.snap
@@ -10,19 +10,19 @@ type elem<'t> =
   | Empty: elem<empty>
   | Element(renderable<('s, 'a) => 'sub>): elem<('s, 'a) => 'sub>
   | TwoElements(elem<'t1>, elem<'t2>): elem<('t1, 't2)>
-  /*
+  | /*
    * Not an ordered map yet, but should be.
    */
-  | ElementMap(list<elem<'t>>): elem<list<'t>>
+  ElementMap(list<elem<'t>>): elem<list<'t>>
 /**
  * Instance subtree. Mirrors the shape of JSX, instead of just being a List.
  */
 and subtree<'t> =
   | EmptyInstance: subtree<empty>
   | Instance(inst<('s, 'a) => 'sub>): subtree<('s, 'a) => 'sub>
-  /* Having TwoInstances mirror the fact that TwoElements requires sub
+  | /* Having TwoInstances mirror the fact that TwoElements requires sub
    * elements, was probably overkill. */
-  | TwoInstances(subtree<'t1>, subtree<'t2>): subtree<('t1, 't2)>
+  TwoInstances(subtree<'t1>, subtree<'t2>): subtree<('t1, 't2)>
   | InstanceMap(list<subtree<'t>>): subtree<list<'t>>
 and reducer<'t> = (inst<'t>, 'a) => 's constraint 't = ('s, 'a) => 'sub
 /*
@@ -31,8 +31,8 @@ and reducer<'t> = (inst<'t>, 'a) => 's constraint 't = ('s, 'a) => 'sub
  * static-by-default trees, you don't need to define a record beforehand.
  */
 and componentSpec<'t> =
-  /* Add more forms here for convenience */
-  | Reducer('s, elem<'sub>, reducer<'t>) constraint 't = ('s, 'a) => 'sub
+  | /* Add more forms here for convenience */
+  Reducer('s, elem<'sub>, reducer<'t>) constraint 't = ('s, 'a) => 'sub
 and self<'t> = {
   reduceEvent: 'e. ('e => 'a, 'e) => unit,
   /**

--- a/tests/printer/typeDef/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typeDef/__snapshots__/render.spec.js.snap
@@ -275,6 +275,7 @@ type node<_, 'value> =
       mutable value: 'value,
       mutable updatedTime: float,
     }): node<root, 'value>
+
   | Derived({
       mutable cachedValue: 'value,
       parent: node<_, 'value>,


### PR DESCRIPTION
See https://github.com/BuckleScript/syntax/issues/50