### PR TITLE
Uppercase Generics

### DIFF
--- a/src/napkin_diagnostics.ml
+++ b/src/napkin_diagnostics.ml
@@ -1,6 +1,7 @@
 module Reporting = Napkin_reporting
 module Grammar = Napkin_grammar
 module Token = Napkin_token
+
 type category =
   | Unexpected of {token: Token.t; context: (Grammar.t * Lexing.position) list}
   | Expected of {context: Grammar.t option; pos: Lexing.position (* prev token end*); token: Token.t}

--- a/src/napkin_printer.ml
+++ b/src/napkin_printer.ml
@@ -1435,7 +1435,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
   | Ptyp_any -> Doc.text "_"
   | Ptyp_var var -> Doc.concat [
       Doc.text "'";
-      printIdentLike var;
+      printIdentLike ~allowUident:true var;
     ]
   | Ptyp_extension(extension) ->
     printExtension ~atModuleLvl:false extension cmtTbl

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -174,7 +174,19 @@ exports[`typeParams.js 1`] = `
 "=====Parsetree==========================================
 type nonrec 'a node = {
   _value: 'a Js.Nullable.value }
-type nonrec ('from, '_) derivedNode =
+type nonrec ('from, 'to) derivedNode =
+  {
+  mutable value: 'to_ ;
+  updateF: 'from -> 'to_ }
+type nonrec ('from, ') derivedNode =
+  {
+  mutable value: 'to_ ;
+  updateF: 'from -> 'to_ }
+type nonrec ('from, ') derivedNode =
+  {
+  mutable value: 'to_ ;
+  updateF: 'from -> 'to_ }
+type nonrec ('from, 'foo) derivedNode =
   {
   mutable value: 'to_ ;
   updateF: 'from -> 'to_ }
@@ -202,6 +214,42 @@ File \\"/syntax/tests/parsing/errors/typeDef/typeParams.js\\", line 5, character
 7 │    updateF: 'from => 'to_,
 
 \`to\` is a reserved keyword. Keywords need to be escaped: \\\\\\"to\\"
+
+
+File \\"/syntax/tests/parsing/errors/typeDef/typeParams.js\\", line 10, characters 25-26:
+
+
+8 │  }
+9 │  
+[31m10[0m │  type derivedNode<'from, '[31m+[0m> = {
+11 │    mutable value: 'to_,
+12 │    updateF: 'from => 'to_,
+
+A type param consists of a singlequote followed by a name like \`'a\` or \`'A\`
+
+
+File \\"/syntax/tests/parsing/errors/typeDef/typeParams.js\\", line 15, characters 25-26:
+
+
+13 │  }
+14 │  
+[31m15[0m │  type derivedNode<'from, '[31m_[0m> = {
+16 │    mutable value: 'to_,
+17 │    updateF: 'from => 'to_,
+
+A type param consists of a singlequote followed by a name like \`'a\` or \`'A\`
+
+
+File \\"/syntax/tests/parsing/errors/typeDef/typeParams.js\\", line 21, characters 24-27:
+
+
+19 │  
+20 │  
+[31m21[0m │  type derivedNode<'from, [31mfoo[0m> = {
+22 │    mutable value: 'to_,
+23 │    updateF: 'from => 'to_,
+
+Type params start with a singlequote: 'foo
 
 
 

--- a/tests/parsing/errors/typeDef/typeParams.js
+++ b/tests/parsing/errors/typeDef/typeParams.js
@@ -6,3 +6,19 @@ type derivedNode<'from, 'to> = {
   mutable value: 'to_,
   updateF: 'from => 'to_,
 }
+
+type derivedNode<'from, '+> = {
+  mutable value: 'to_,
+  updateF: 'from => 'to_,
+}
+
+type derivedNode<'from, '_> = {
+  mutable value: 'to_,
+  updateF: 'from => 'to_,
+}
+
+
+type derivedNode<'from, foo> = {
+  mutable value: 'to_,
+  updateF: 'from => 'to_,
+}

--- a/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
@@ -291,3 +291,31 @@ I'm not sure what to parse here when looking at \\")\\".
 
 ========================================================"
 `;
+
+exports[`typeVar.res 1`] = `
+"=====Parsetree==========================================
+type nonrec 'A x = '
+type nonrec 'A x = 'let
+=====Errors=============================================
+
+File \\"/syntax/tests/parsing/errors/typexpr/typeVar.res\\", line 1, characters 14-15:
+
+
+[31m1[0m │  type x<'A> = '[31m_[0m
+2 │  type x<'A> = 'let
+
+A type variable consists of a singlequote followed by a name like \`'a\` or \`'A\`
+
+
+File \\"/syntax/tests/parsing/errors/typexpr/typeVar.res\\", line 2, characters 14-17:
+
+
+1 │  type x<'A> = '_
+[31m2[0m │  type x<'A> = '[31mlet[0m
+
+\`let\` is a reserved keyword. Keywords need to be escaped: \\\\\\"let\\"
+
+
+
+========================================================"
+`;

--- a/tests/parsing/errors/typexpr/typeVar.res
+++ b/tests/parsing/errors/typexpr/typeVar.res
@@ -1,0 +1,2 @@
+type x<'A> = '_
+type x<'A> = 'let

--- a/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
@@ -226,5 +226,6 @@ exports[`var.js 1`] = `
 let (t : 'a) = x
 let t : 'a . t = x
 let t : 'a 'b . t = x
-let t : 'a 'b 'c . t = x"
+let t : 'a 'b 'c . t = x
+type nonrec 'A x = 'A"
 `;

--- a/tests/parsing/grammar/typexpr/var.js
+++ b/tests/parsing/grammar/typexpr/var.js
@@ -4,3 +4,5 @@ let t: 'a = x
 let t: 'a. t = x
 let t: 'a 'b. t = x
 let t: 'a 'b 'c. t = x
+
+type x<'A> = 'A

--- a/tests/printer/typeDef/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typeDef/__snapshots__/render.spec.js.snap
@@ -80,7 +80,7 @@ type \\\\\\"Color\\" =
 
 type \\\\\\"type\\"<'\\\\\\"😱 gadt\\", '\\\\\\"😻\\"> constraint '\\\\\\"type\\" = \\\\\\"let\\"
 
-type \\\\\\"type\\"<'\\\\\\"SuperIdent\\"> += Blue(\\\\\\"type\\", \\\\\\"ExtremeType\\")
+type \\\\\\"type\\"<'\\\\\\"😆SuperIdent\\"> += Blue(\\\\\\"type\\", \\\\\\"ExtremeType\\")
 "
 `;
 
@@ -210,6 +210,11 @@ type t<
   -'superlongthing,
   +'superlongthing,
 > constraint 't = ('state, 'action) => 'nextSubtree
+
+module Test = {
+  type x<'A> = 'A
+  type y = x<string>
+}
 "
 `;
 

--- a/tests/printer/typeDef/exoticIdent.js
+++ b/tests/printer/typeDef/exoticIdent.js
@@ -10,4 +10,4 @@ type \"Color" =
 type \"type"<'\"😱 gadt", '\"😻">
   constraint '\"type" = \"let"
 
-type \"type"<'\"SuperIdent"> += Blue(\"type", \"ExtremeType") 
+type \"type"<'\"😆SuperIdent"> += Blue(\"type", \"ExtremeType") 

--- a/tests/printer/typeDef/typeParams.js
+++ b/tests/printer/typeDef/typeParams.js
@@ -7,3 +7,8 @@ type t<+'superlongthing, -'superlongthing, +'superlongthing, -'superlongthing, +
 
 type t<+'superlongthing, -'superlongthing, +'superlongthing, -'superlongthing, +'superlongthing>
   constraint 't = ('state, 'action) => 'nextSubtree
+
+module Test = {
+  type x<'A> = 'A
+  type y = x<string>
+}

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -572,6 +572,8 @@ external foo: @attr 'foo = \\"primitive\\"
 
 let x: 'a = y
 let x: @attr 'a = y
+
+type x<'A> = 'A
 "
 `;
 

--- a/tests/printer/typexpr/var.js
+++ b/tests/printer/typexpr/var.js
@@ -8,3 +8,5 @@ external foo: @attr 'foo = "primitive"
 
 let x: 'a = y
 let x: @attr 'a = y
+
+type x<'A> = 'A


### PR DESCRIPTION
Allow uppercase identifiers in type params and typexpr variables

```typescript
type x<'A> = 'A
```

Fixes https://github.com/BuckleScript/syntax/issues/49