### PR TITLE
Fix location for external declaration with attributes.

### DIFF
--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -4889,8 +4889,7 @@ and parsePrimitives p =
   | primitives -> primitives
 
 (* external value-name : typexp = external-declaration *)
-and parseExternalDef ~attrs p =
-  let startPos = p.Parser.startPos in
+and parseExternalDef ~attrs ~startPos p =
   Parser.leaveBreadcrumb p Grammar.External;
   Parser.expect Token.External p;
   let (name, loc) = parseLident p in
@@ -4997,7 +4996,7 @@ and parseStructureItemRegion p =
       Some (Ast_helper.Str.type_extension ~loc ext)
     end
   | External ->
-    let externalDef = parseExternalDef ~attrs p in
+    let externalDef = parseExternalDef ~attrs ~startPos p in
     parseNewlineOrSemicolonStructure p;
     let loc = mkLoc startPos p.prevEndPos in
     Some (Ast_helper.Str.primitive ~loc externalDef)
@@ -5705,7 +5704,7 @@ and parseSignatureItemRegion p =
       Some (Ast_helper.Sig.type_extension ~loc ext)
     end
   | External ->
-    let externalDef = parseExternalDef ~attrs p in
+    let externalDef = parseExternalDef ~attrs ~startPos p in
     parseNewlineOrSemicolonSignature p;
     let loc = mkLoc startPos p.prevEndPos in
     Some (Ast_helper.Sig.value ~loc externalDef)


### PR DESCRIPTION
The location should start from the attributes.

e.g.
```swift
@bs.module("BootloaderResource") external read: JSResource.t<'a> => 'a = "read"
```
the location should start from `@` not from `e` of `external`.