### PR TITLE
Document uncurried conversion through test cases.

### DIFF
--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1220,6 +1220,61 @@ exports[`ternary.re 1`] = `
 "
 `;
 
+exports[`uncurrried.re 1`] = `
+"// ok
+let updateBriefletNarrative = (. updateObj) =>
+  Js.log(\\"patented merge algorithm goes here\\")
+
+// this is a bug in Reason, the . will be parsed wrong and disappear.
+updateBriefletNarrative(briefletNarrativeUpdateObj)
+
+// this is a bug in Reason, the . will be parsed wrong and disappear.
+foo(3)
+
+module D = {
+  // this is a bug in Reason, the . will be parsed wrong and disappear.
+  foo(3)
+}
+
+// ok
+let x = foo(. 3)
+
+let x = {
+  let a = 3
+  // ok
+  foo(. a)
+}
+
+let x = {
+  // ok
+  let f = (. a, b) => apply(. a + b)
+  let a = 3
+  // ok
+  foo(. a)
+  // ok
+  f(. 2, 2)
+}
+
+// ok
+let () = switch something(. x, y) {
+| None =>
+  // ok
+  log(. a, b)
+| Some(_) =>
+  let a = 1
+  // ok
+  log(. a, 2)
+}
+
+let () = {
+  // ok
+  let dontDoThisAhome = (. a, b, . c, d, . e, f) => a + b + c + d + e + f
+  // ok
+  dontDoThisAhome(. a, b)(. c, d)(. e, f)
+}
+"
+`;
+
 exports[`unicode.re 1`] = `
 "let x = \\"✅ foo bar\\"
 

--- a/tests/conversion/reason/uncurrried.re
+++ b/tests/conversion/reason/uncurrried.re
@@ -1,0 +1,58 @@
+// ok
+let updateBriefletNarrative = (. updateObj) => {
+  Js.log("patented merge algorithm goes here")
+}
+
+// this is a bug in Reason, the . will be parsed wrong and disappear.
+updateBriefletNarrative(. briefletNarrativeUpdateObj);
+
+// this is a bug in Reason, the . will be parsed wrong and disappear.
+foo(. 3);
+
+module D = {
+  // this is a bug in Reason, the . will be parsed wrong and disappear.
+  foo(. 3);
+};
+
+// ok
+let x = foo(. 3);
+
+let x = {
+  let a = 3;
+  // ok
+  foo(. a);
+};
+
+let x = {
+  // ok
+  let f = (. a, b) => apply(. a + b)
+  let a = 3;
+  // ok
+  foo(. a);
+  // ok
+  f(. 2, 2);
+};
+
+// ok
+let () = switch (something(. x, y)) {
+| None =>
+  // ok
+  log(. a, b);
+| Some(_) =>
+  let a = 1;
+  // ok
+  log(. a, 2);
+}
+
+let () = {
+  // ok
+  let dontDoThisAhome = (. a, b) => {
+    (. c , d) => {
+      (. e, f) => {
+        a + b + c + d + e + f
+      }
+    }
+  }
+  // ok
+  dontDoThisAhome(. a, b)(. c, d)(. e, f)
+}


### PR DESCRIPTION
Unfortunately there's a bug in the Reason parser.
`f(. a)` will parse the `@bs` attribute in the wrong place, when it's an expression at the module level: https://github.com/facebook/reason/issues/2565

The new Res syntax has the correct behaviour. Unfortunately we can't
fix bugs from Reason, we would change the semantics of the program.