### PR TITLE
Report errors when parsing type expressions.

### DIFF
--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -3639,6 +3639,7 @@ and parseAtomicTypExpr ~attrs p =
   | Lbrace ->
     parseBsObjectType ~attrs p
   | token ->
+    Parser.err p (Diagnostics.unexpected token p.breadcrumbs);
     begin match skipTokensAndMaybeRetry p ~isStartOfGrammar:Grammar.isAtomicTypExprStart with
     | Some () ->
       parseAtomicTypExpr ~attrs p

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -65,10 +65,10 @@ type nonrec z = [< \`A  | \`B ]
 type t = [ [%napkinscript.typehole ] | [%napkinscript.typehole ]]
 =====Errors=============================================
 
-File \\"/syntax/tests/parsing/errors/typeDef/polyvariant.js\\", line 1, characters 13-19:
+File \\"/syntax/tests/parsing/errors/typeDef/polyvariant.js\\", line 1, characters 12-13:
 
 
-[31m1[0m │  type t = [< ]
+[31m1[0m │  type t = [< [31m][0m
 2 │  
 3 │  type t = [ s ]
 
@@ -88,12 +88,12 @@ File \\"/syntax/tests/parsing/errors/typeDef/polyvariant.js\\", line 3, characte
 Did you forget a \`|\` here? 
 
 
-File \\"/syntax/tests/parsing/errors/typeDef/polyvariant.js\\", line 7, characters 15-17:
+File \\"/syntax/tests/parsing/errors/typeDef/polyvariant.js\\", line 7, characters 14-15:
 
 
 5 │  type z = [< | #A | #B > ]
 6 │  
-[31m7[0m │  type rec t = []
+[31m7[0m │  type rec t = [[31m][0m
 8 │  
 
 I'm not sure what to parse here when looking at \\"]\\".
@@ -111,12 +111,12 @@ type nonrec observation =
   observer: [%napkinscript.typehole ] }
 =====Errors=============================================
 
-File \\"/syntax/tests/parsing/errors/typeDef/record.res\\", line 4, characters 1-2:
+File \\"/syntax/tests/parsing/errors/typeDef/record.res\\", line 4, characters 0-1:
 
 
 2 │    observed: int,
 3 │    observer:
-[31m4[0m │  }
+[31m4[0m │  [31m}[0m
 
 I'm missing a type here
 
@@ -144,24 +144,21 @@ File \\"/syntax/tests/parsing/errors/typeDef/typeDef.js\\", line 1, characters 1
 Did you forget a \`=\` here? 
 
 
-File \\"/syntax/tests/parsing/errors/typeDef/typeDef.js\\", line 5, characters 8-30:
+File \\"/syntax/tests/parsing/errors/typeDef/typeDef.js\\", line 8, characters 0-4:
 
 
-3 │  
-4 │  // missing type
-[31m5[0m │  type t =
 6 │  
 7 │  // missing type
+[31m8[0m │  [31mtype[0m state =
 
 Missing a type here
 
 
-File \\"/syntax/tests/parsing/errors/typeDef/typeDef.js\\", line 8, characters 12-13:
+File \\"/syntax/tests/parsing/errors/typeDef/typeDef.js\\", line 9, characters 0-0:
 
 
-6 │  
 7 │  // missing type
-[31m8[0m │  type state =
+8 │  type state =
 
 Missing a type here
 

--- a/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
@@ -227,6 +227,25 @@ Did you forget a \`:\` here? It signals the start of a type
 ========================================================"
 `;
 
+exports[`garbage.res 1`] = `
+"=====Parsetree==========================================
+external printName : name:unit -> unit = \\"printName\\"[@@bs.module
+                                                      \\"moduleName\\"]
+=====Errors=============================================
+
+File \\"/syntax/tests/parsing/errors/typexpr/garbage.res\\", line 2, characters 27-28:
+
+
+1 │  @bs.module(\\"moduleName\\")
+[31m2[0m │  external printName: (~name:[31m?[0m, unit) => unit = \\"printName\\"
+
+I'm not sure what to parse here when looking at \\"?\\".
+
+
+
+========================================================"
+`;
+
 exports[`typeConstructorArgs.js 1`] = `
 "=====Parsetree==========================================
 type nonrec 'a node = {

--- a/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
@@ -139,48 +139,48 @@ File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 19, characte
 Did you forget a \`:\` here? It signals the start of a type
 
 
-File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 24, characters 19-21:
+File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 25, characters 0-1:
 
 
-22 │  type state = {
 23 │    @bs.meth
-[31m24[0m │    \\"send\\": string =>
-25 │  }
+24 │    \\"send\\": string =>
+[31m25[0m │  [31m}[0m
 26 │  
+27 │  type state = {
 
 I'm missing a type here
 
 
-File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 28, characters 10-19:
+File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 28, characters 9-10:
 
 
 26 │  
 27 │  type state = {
-[31m28[0m │    \\"age\\": ,
+[31m28[0m │    \\"age\\": [31m,[0m
 29 │    \\"name\\": string
 30 │  }
 
 I'm missing a type here
 
 
-File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 33, characters 18-27:
+File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 33, characters 17-18:
 
 
 31 │  
 32 │  type state = {
-[31m33[0m │    @bs.set \\"age\\": ,
+[31m33[0m │    @bs.set \\"age\\": [31m,[0m
 34 │    \\"name\\": string
 35 │  }
 
 I'm missing a type here
 
 
-File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 37, characters 23-25:
+File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 37, characters 24-25:
 
 
 35 │  }
 36 │  
-[31m37[0m │  type state = {.. \\"age\\":[31m }[0m
+[31m37[0m │  type state = {.. \\"age\\": [31m}[0m
 38 │  type state = {
 39 │    ..
 
@@ -200,14 +200,14 @@ File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 40, characte
 Did you forget a \`:\` here? It signals the start of a type
 
 
-File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 45, characters 7-19:
+File \\"/syntax/tests/parsing/errors/typexpr/bsObjSugar.js\\", line 46, characters 2-11:
 
 
-43 │  
 44 │  type websocket = {
-[31m45[0m │    \\"id\\":
-46 │    \\"channel\\": channelTyp
+45 │    \\"id\\":
+[31m46[0m │    [31m\\"channel\\"[0m: channelTyp
 47 │  }
+48 │  
 
 I'm missing a type here
 

--- a/tests/parsing/errors/typexpr/garbage.res
+++ b/tests/parsing/errors/typexpr/garbage.res
@@ -1,0 +1,2 @@
+@bs.module("moduleName")
+external printName: (~name:?, unit) => unit = "printName"


### PR DESCRIPTION
Report errors when encountering unexpected tokens in atomic type expressions. Previously errors just weren't logged at all.

Fixes https://github.com/BuckleScript/syntax/issues/48