### PR TITLE
Expose API to seed the initial line number of the parser.

### DIFF
--- a/.depend
+++ b/.depend
@@ -75,5 +75,6 @@ src/napkin_scanner.cmx : src/napkin_token.cmx src/napkin_diagnostics.cmx \
     src/napkin_scanner.cmi
 src/napkin_scanner.cmi : src/napkin_token.cmx src/napkin_diagnostics.cmi
 src/napkin_token.cmx : src/napkin_comment.cmx src/napkin_character_codes.cmx
-tests/napkin_test.cmx : src/napkin_outcome_printer.cmx \
-    src/napkin_multi_printer.cmx src/napkin_io.cmx src/napkin_driver.cmx
+tests/napkin_test.cmx : src/napkin_token.cmx src/napkin_parser.cmx \
+    src/napkin_outcome_printer.cmx src/napkin_multi_printer.cmx \
+    src/napkin_io.cmx src/napkin_driver.cmx

--- a/src/napkin_parser.ml
+++ b/src/napkin_parser.ml
@@ -8,152 +8,150 @@ module Comment = Napkin_comment
 
 type mode = ParseForTypeChecker | Default
 
-  type regionStatus = Report | Silent
+type regionStatus = Report | Silent
 
-  type t = {
-    mode: mode;
-    mutable scanner: Scanner.t;
-    mutable token: Token.t;
-    mutable startPos: Lexing.position;
-    mutable endPos: Lexing.position;
-    mutable prevEndPos: Lexing.position;
-    mutable breadcrumbs: (Grammar.t * Lexing.position) list;
-    mutable errors: Reporting.parseError list;
-    mutable diagnostics: Diagnostics.t list;
-    mutable comments: Comment.t list;
-    mutable regions: regionStatus ref list;
-  }
+type t = {
+  mode: mode;
+  mutable scanner: Scanner.t;
+  mutable token: Token.t;
+  mutable startPos: Lexing.position;
+  mutable endPos: Lexing.position;
+  mutable prevEndPos: Lexing.position;
+  mutable breadcrumbs: (Grammar.t * Lexing.position) list;
+  mutable errors: Reporting.parseError list;
+  mutable diagnostics: Diagnostics.t list;
+  mutable comments: Comment.t list;
+  mutable regions: regionStatus ref list;
+}
 
-  let err ?startPos ?endPos p error =
-    let d = Diagnostics.make
-      ~filename:p.scanner.filename
-      ~startPos:(match startPos with | Some pos -> pos | None -> p.startPos)
-      ~endPos:(match endPos with | Some pos -> pos | None -> p.endPos)
+let err ?startPos ?endPos p error =
+  let d = Diagnostics.make
+    ~filename:p.scanner.filename
+    ~startPos:(match startPos with | Some pos -> pos | None -> p.startPos)
+    ~endPos:(match endPos with | Some pos -> pos | None -> p.endPos)
+    error
+  in
+  try
+    if (!(List.hd p.regions) = Report) then (
+      p.diagnostics <- d::p.diagnostics;
+      List.hd p.regions := Silent
+    )
+  with Failure _ -> ()
+
+let beginRegion p =
+  p.regions <- ref Report :: p.regions
+let endRegion p =
+  try p.regions <- List.tl p.regions with Failure _ -> ()
+
+(* Advance to the next non-comment token and store any encountered comment
+* in the parser's state. Every comment contains the end position of its
+* previous token to facilite comment interleaving *)
+let rec next ?prevEndPos p =
+ let prevEndPos = match prevEndPos with Some pos -> pos | None -> p.endPos in
+ let (startPos, endPos, token) = Scanner.scan p.scanner in
+ match token with
+ | Comment c ->
+   Comment.setPrevTokEndPos c p.endPos;
+   p.comments <- c::p.comments;
+   p.prevEndPos <- p.endPos;
+   p.endPos <- endPos;
+   next ~prevEndPos p
+ | _ ->
+   p.token <- token;
+   (* p.prevEndPos <- prevEndPos; *)
+   p.prevEndPos <- prevEndPos;
+   p.startPos <- startPos;
+   p.endPos <- endPos
+
+let checkProgress ~prevEndPos ~result p =
+  if p.endPos == prevEndPos
+  then None
+  else Some result
+
+let make ?(mode=ParseForTypeChecker) ?line src filename =
+  let scanner = Scanner.make ~filename ?line (Bytes.of_string src) in
+  let parserState = {
+    mode;
+    scanner;
+    token = Token.Eof;
+    startPos = Lexing.dummy_pos;
+    prevEndPos = Lexing.dummy_pos;
+    endPos = Lexing.dummy_pos;
+    breadcrumbs = [];
+    errors = [];
+    diagnostics = [];
+    comments = [];
+    regions = [ref Report];
+  } in
+  parserState.scanner.err <- (fun ~startPos ~endPos error ->
+    let diagnostic = Diagnostics.make
+      ~filename
+      ~startPos
+      ~endPos
       error
     in
-    try
-      if (!(List.hd p.regions) = Report) then (
-        p.diagnostics <- d::p.diagnostics;
-        List.hd p.regions := Silent
-      )
-    with Failure _ -> ()
+    parserState.diagnostics <- diagnostic::parserState.diagnostics
+  );
+  next parserState;
+  parserState
 
-  let beginRegion p =
-    p.regions <- ref Report :: p.regions
-  let endRegion p =
-    try p.regions <- List.tl p.regions with Failure _ -> ()
+let leaveBreadcrumb p circumstance =
+  let crumb = (circumstance, p.startPos) in
+  p.breadcrumbs <- crumb::p.breadcrumbs
 
-   (* Advance to the next non-comment token and store any encountered comment
-    * in the parser's state. Every comment contains the end position of its
-    * previous token to facilite comment interleaving *)
-   let rec next ?prevEndPos p =
-     let prevEndPos = match prevEndPos with Some pos -> pos | None -> p.endPos in
-     let (startPos, endPos, token) = Scanner.scan p.scanner in
-     match token with
-     | Comment c ->
-       Comment.setPrevTokEndPos c p.endPos;
-       p.comments <- c::p.comments;
-       p.prevEndPos <- p.endPos;
-       p.endPos <- endPos;
-       next ~prevEndPos p
-     | _ ->
-       p.token <- token;
-       (* p.prevEndPos <- prevEndPos; *)
-       p.prevEndPos <- prevEndPos;
-       p.startPos <- startPos;
-       p.endPos <- endPos
+let eatBreadcrumb p =
+  match p.breadcrumbs with
+  | [] -> ()
+  | _::crumbs -> p.breadcrumbs <- crumbs
 
-  let checkProgress ~prevEndPos ~result p =
-    if p.endPos == prevEndPos
-    then None
-    else Some result
+let optional p token =
+  if p.token = token then
+    let () = next p in true
+  else
+    false
 
-  let make ?(mode=ParseForTypeChecker) src filename =
-    let scanner = Scanner.make (Bytes.of_string src) filename in
-    let parserState = {
-      mode;
-      scanner;
-      token = Token.Eof;
-      startPos = Lexing.dummy_pos;
-      prevEndPos = Lexing.dummy_pos;
-      endPos = Lexing.dummy_pos;
-      breadcrumbs = [];
-      errors = [];
-      diagnostics = [];
-      comments = [];
-      regions = [ref Report];
-    } in
-    parserState.scanner.err <- (fun ~startPos ~endPos error ->
-      let diagnostic = Diagnostics.make
-        ~filename
-        ~startPos
-        ~endPos
-        error
-      in
-      parserState.diagnostics <- diagnostic::parserState.diagnostics
-    );
-    next parserState;
-    parserState
+let expect ?grammar token p =
+  if p.token = token then
+    next p
+  else
+    let error = Diagnostics.expected ?grammar p.prevEndPos token in
+    err ~startPos:p.prevEndPos p error
 
-  let leaveBreadcrumb p circumstance =
-    let crumb = (circumstance, p.startPos) in
-    p.breadcrumbs <- crumb::p.breadcrumbs
+(* Don't use immutable copies here, it trashes certain heuristics
+ * in the ocaml compiler, resulting in massive slowdowns of the parser *)
+let lookahead p callback =
+  let err = p.scanner.err in
+  let ch = p.scanner.ch in
+  let offset = p.scanner.offset in
+  let rdOffset = p.scanner.rdOffset in
+  let lineOffset = p.scanner.lineOffset in
+  let lnum = p.scanner.lnum in
+  let mode = p.scanner.mode in
+  let token = p.token in
+  let startPos = p.startPos in
+  let endPos = p.endPos in
+  let prevEndPos = p.prevEndPos in
+  let breadcrumbs = p.breadcrumbs in
+  let errors = p.errors in
+  let diagnostics = p.diagnostics in
+  let comments = p.comments in
 
-  let eatBreadcrumb p =
-    match p.breadcrumbs with
-    | [] -> ()
-    | _::crumbs -> p.breadcrumbs <- crumbs
+  let res = callback p in
 
-  let optional p token =
-    if p.token = token then
-      let () = next p in true
-    else
-      false
+  p.scanner.err <- err;
+  p.scanner.ch <- ch;
+  p.scanner.offset <- offset;
+  p.scanner.rdOffset <- rdOffset;
+  p.scanner.lineOffset <- lineOffset;
+  p.scanner.lnum <- lnum;
+  p.scanner.mode <- mode;
+  p.token <- token;
+  p.startPos <- startPos;
+  p.endPos <- endPos;
+  p.prevEndPos <- prevEndPos;
+  p.breadcrumbs <- breadcrumbs;
+  p.errors <- errors;
+  p.diagnostics <- diagnostics;
+  p.comments <- comments;
 
-  let expect ?grammar token p =
-    if p.token = token then
-      next p
-    else
-      let error = Diagnostics.expected ?grammar p.prevEndPos token in
-      err ~startPos:p.prevEndPos p error
-
-  (* Don't use immutable copies here, it trashes certain heuristics
-   * in the ocaml compiler, resulting in massive slowdowns of the parser *)
-  let lookahead p callback =
-    let err = p.scanner.err in
-    let ch = p.scanner.ch in
-    let offset = p.scanner.offset in
-    let rdOffset = p.scanner.rdOffset in
-    let lineOffset = p.scanner.lineOffset in
-    let lnum = p.scanner.lnum in
-    let mode = p.scanner.mode in
-    let token = p.token in
-    let startPos = p.startPos in
-    let endPos = p.endPos in
-    let prevEndPos = p.prevEndPos in
-    let breadcrumbs = p.breadcrumbs in
-    let errors = p.errors in
-    let diagnostics = p.diagnostics in
-    let comments = p.comments in
-
-    let res = callback p in
-
-    p.scanner.err <- err;
-    p.scanner.ch <- ch;
-    p.scanner.offset <- offset;
-    p.scanner.rdOffset <- rdOffset;
-    p.scanner.lineOffset <- lineOffset;
-    p.scanner.lnum <- lnum;
-    p.scanner.mode <- mode;
-    p.token <- token;
-    p.startPos <- startPos;
-    p.endPos <- endPos;
-    p.prevEndPos <- prevEndPos;
-    p.breadcrumbs <- breadcrumbs;
-    p.errors <- errors;
-    p.diagnostics <- diagnostics;
-    p.comments <- comments;
-
-    res
-
-
+  res

--- a/src/napkin_parser.mli
+++ b/src/napkin_parser.mli
@@ -22,7 +22,7 @@ type t = {
   mutable regions: regionStatus ref list;
 }
 
-val make: ?mode: mode -> string -> string -> t
+val make: ?mode: mode -> ?line:int -> string -> string -> t
 
 val expect: ?grammar:Grammar.t -> Token.t -> t -> unit
 val optional: t -> Token.t -> bool

--- a/src/napkin_parser.mli
+++ b/src/napkin_parser.mli
@@ -22,7 +22,8 @@ type t = {
   mutable regions: regionStatus ref list;
 }
 
-val make: ?mode: mode -> ?line:int -> string -> string -> t
+(* `line` seeds the parser's state with an initial line number. *)
+val make: ?mode:mode -> ?line:int -> string -> string -> t
 
 val expect: ?grammar:Grammar.t -> Token.t -> t -> unit
 val optional: t -> Token.t -> bool

--- a/src/napkin_reason_binary_driver.ml
+++ b/src/napkin_reason_binary_driver.ml
@@ -15,7 +15,7 @@ let extractConcreteSyntax filename =
     if String.length filename > 0 then IO.readFile ~filename
     else IO.readStdin ()
   in
-  let scanner = Napkin_scanner.make (Bytes.of_string src) filename in
+  let scanner = Napkin_scanner.make (Bytes.of_string src) ~filename in
 
   let rec next prevEndPos scanner =
     let (startPos, endPos, token) = Napkin_scanner.scan scanner in

--- a/src/napkin_scanner.ml
+++ b/src/napkin_scanner.ml
@@ -77,7 +77,7 @@ let peek scanner =
   else
     -1
 
-let make b filename =
+let make ?(line=1) ~filename b =
   let scanner = {
     filename;
     src = b;
@@ -86,7 +86,7 @@ let make b filename =
     offset = 0;
     rdOffset = 0;
     lineOffset = 0;
-    lnum = 1;
+    lnum = line;
     mode = [];
   } in
   next scanner;

--- a/src/napkin_scanner.mli
+++ b/src/napkin_scanner.mli
@@ -1,32 +1,31 @@
-
 type mode = Template | Jsx | Diamond
 
-  type t = {
-    filename: string;
-    src: bytes;
-    mutable err:
-      startPos: Lexing.position
-      -> endPos: Lexing.position
-      -> Napkin_diagnostics.category
-      -> unit;
-    mutable ch: int; (* current character *)
-    mutable offset: int; (* character offset *)
-    mutable rdOffset: int; (* reading offset (position after current character) *)
-    mutable lineOffset: int; (* current line offset *)
-    mutable lnum: int; (* current line number *)
-    mutable mode: mode list;
-  }
+type t = {
+  filename: string;
+  src: bytes;
+  mutable err:
+    startPos: Lexing.position
+    -> endPos: Lexing.position
+    -> Napkin_diagnostics.category
+    -> unit;
+  mutable ch: int; (* current character *)
+  mutable offset: int; (* character offset *)
+  mutable rdOffset: int; (* reading offset (position after current character) *)
+  mutable lineOffset: int; (* current line offset *)
+  mutable lnum: int; (* current line number *)
+  mutable mode: mode list;
+}
 
-  val make: bytes -> string -> t
+val make: ?line:int -> filename:string -> bytes -> t
 
-  (* TODO: make this a record *)
-  val scan: t -> (Lexing.position * Lexing.position * Napkin_token.t)
+(* TODO: make this a record *)
+val scan: t -> (Lexing.position * Lexing.position * Napkin_token.t)
 
-  val isBinaryOp: bytes -> int -> int -> bool
+val isBinaryOp: bytes -> int -> int -> bool
 
-  val setTemplateMode: t -> unit
-  val setJsxMode: t -> unit
-  val setDiamondMode: t -> unit
-  val popMode: t -> mode -> unit
+val setTemplateMode: t -> unit
+val setJsxMode: t -> unit
+val setDiamondMode: t -> unit
+val popMode: t -> mode -> unit
 
-  val reconsiderLessThan: t -> Napkin_token.t
+val reconsiderLessThan: t -> Napkin_token.t

--- a/tests/napkin_test.ml
+++ b/tests/napkin_test.ml
@@ -176,4 +176,18 @@ module OutcomePrinterTests = struct
     Snapshot.take ~filename:testFileName ~contents:printedOutcomeTree
 end
 
+module ParserApiTest = struct
+  let run () =
+    let src = "let x = 1\nlet y = 2\nlet z = 3" in
+    let parser = Napkin_parser.make ~line:2 src "test.res" in
+    assert (parser.scanner.lnum == 2);
+    assert (parser.scanner.lineOffset == 0);
+    assert (parser.scanner.offset == 3);
+    assert (parser.scanner.rdOffset == 4);
+    assert (parser.token = Napkin_token.Let);
+    print_endline "✅ Parser make: initializes scanner with line set to 2"
+
+end
+
 let () = OutcomePrinterTests.run()
+let () = ParserApiTest.run()

--- a/tests/napkin_test.ml
+++ b/tests/napkin_test.ml
@@ -177,7 +177,17 @@ module OutcomePrinterTests = struct
 end
 
 module ParserApiTest = struct
-  let run () =
+  let makeDefault () =
+    let src = "   let x = 1\nlet y = 2\nlet z = 3" in
+    let parser = Napkin_parser.make  src "test.res" in
+    assert (parser.scanner.lnum == 1);
+    assert (parser.scanner.lineOffset == 0);
+    assert (parser.scanner.offset == 6);
+    assert (parser.scanner.rdOffset == 7);
+    assert (parser.token = Napkin_token.Let);
+    print_endline "✅ Parser make: initializes parser defaulting to line 1 "
+
+  let seedLineNumber () =
     let src = "let x = 1\nlet y = 2\nlet z = 3" in
     let parser = Napkin_parser.make ~line:2 src "test.res" in
     assert (parser.scanner.lnum == 2);
@@ -185,7 +195,11 @@ module ParserApiTest = struct
     assert (parser.scanner.offset == 3);
     assert (parser.scanner.rdOffset == 4);
     assert (parser.token = Napkin_token.Let);
-    print_endline "✅ Parser make: initializes scanner with line set to 2"
+    print_endline "✅ Parser make: initializes parser with line set to 2"
+
+  let run () =
+    makeDefault();
+    seedLineNumber()
 
 end
 


### PR DESCRIPTION
Instead of exposing a surface syntax to change the line number of the scanner at parse time, we can expose a programmatic api for power users to seed the line number
```ocaml
let parser = Napkin_parser.make ~line:2 mySourceCode myFilename
```