### PR TITLE
Exit parser instead of raising error

### DIFF
--- a/src/napkin_driver.ml
+++ b/src/napkin_driver.ml
@@ -95,10 +95,10 @@ let parse_implementation sourcefile =
   if parseResult.invalid then begin
     let style = Napkin_diagnostics.parseReportStyle "" in
     let msg = Napkin_diagnostics.stringOfReport ~style parseResult.diagnostics parseResult.source in
-    raise (Location.Error (Location.error msg))
+    print_endline msg;
+    exit 1
   end;
   parseResult.parsetree
-  [@@raises Location.Error]
 
 let parse_interface sourcefile =
   Location.input_name := sourcefile;
@@ -106,7 +106,7 @@ let parse_interface sourcefile =
   if parseResult.invalid then begin
     let style = Napkin_diagnostics.parseReportStyle "" in
     let msg = Napkin_diagnostics.stringOfReport ~style parseResult.diagnostics parseResult.source in
-    raise (Location.Error (Location.error msg))
+    print_endline msg;
+    exit 1
   end;
   parseResult.parsetree
-  [@@raises Location.Error]

--- a/src/napkin_multi_printer.ml
+++ b/src/napkin_multi_printer.ml
@@ -9,9 +9,12 @@ let printRes ~isInterface ~filename =
       Napkin_driver.parsingEngine.parseInterface ~forPrinter:true ~filename
     in
     if parseResult.invalid then
-      let style = Napkin_diagnostics.parseReportStyle "" in
-      let msg = Napkin_diagnostics.stringOfReport ~style parseResult.diagnostics parseResult.source in
-      raise (Location.Error (Location.error msg))
+      begin
+        let style = Napkin_diagnostics.parseReportStyle "" in
+        let msg = Napkin_diagnostics.stringOfReport ~style parseResult.diagnostics parseResult.source in
+        print_endline msg;
+        exit 1
+      end
     else
       Napkin_printer.printInterface
         ~width:defaultPrintWidth
@@ -22,15 +25,17 @@ let printRes ~isInterface ~filename =
       Napkin_driver.parsingEngine.parseImplementation ~forPrinter:true ~filename
     in
     if parseResult.invalid then
-      let style = Napkin_diagnostics.parseReportStyle "" in
-      let msg = Napkin_diagnostics.stringOfReport ~style parseResult.diagnostics parseResult.source in
-      raise (Location.Error (Location.error msg))
+      begin
+        let style = Napkin_diagnostics.parseReportStyle "" in
+        let msg = Napkin_diagnostics.stringOfReport ~style parseResult.diagnostics parseResult.source in
+        print_endline msg;
+        exit 1
+      end
     else
       Napkin_printer.printImplementation
         ~width:defaultPrintWidth
         ~comments:parseResult.comments
         parseResult.parsetree
-[@@raises Location.Error]
 
 (* print ocaml files to res syntax *)
 let printMl ~isInterface ~filename =
@@ -123,4 +128,4 @@ let print language ~input =
   | `res -> printRes ~isInterface ~filename:input
   | `ml -> printMl ~isInterface ~filename:input
   | `refmt path -> printReason ~refmtPath:path ~isInterface ~filename:input
-[@@raises Location.Error, Sys_error]
+[@@raises Sys_error]


### PR DESCRIPTION
Exit parser instead of raising error

See #68. The problem we have is the 2nd and 3rd screenshots, with a superfluous and nonexistent location reported.

This happens because BS/OCaml's way of reporting an error is to catch e.g. a `Location.Error` exception. The reporting displays the location, then move on. This is problematic for our syntax, because we report more than one error (i.e. we have more than one location to show).

The theoretical solution is to refactor the BS/OCaml reporting pipeline to accept a new exception that allows more than one error. But this shakes things up too much, so our temporary solution is to print all the errors on the syntax side, then simply exit the process. No exception raised means the BS side also doesn't catch anything and tries to display that nonsensical location line.

Caveats
- (Not implemented yet) We need to reproduce the display logic inside the syntax code. We'll use the same display logic as BS' super-errors for now, and assume that most folks using BS also have super-errors turned on (which is the default). The result is that when we run bsb, a syntax error display and a compiler error display are visually consistent, even though they're produced by 2 different pieces of code. The look will be inconsistent if user has super-errors disabled; a type error (from BS) would look rustic, while a syntax error (from here) still looks super. Technically the compiler can invoke the syntax api and pass a flag to make it display the old ocaml error format, but nah.
- Exiting a process is a hard control flow. The compiler can't even "catch" it. This is problematic if the compiler wants to keep operating on the file after syntax errors. Right now there's no such thing as "catching a syntax error and recover and keep analyzing the file", but we'll likely need this in the future when in the editor, the compiler operates on the recovered syntax tree in order to provide best-effort type hint, autocomplete, etc. Can't have the syntax exit the compiler process there =).
- The online playground, compiled through jsoo, naturally doesn't understand "exiting a process". We'll need some patching here.

Anyway, temporary, rather stable solution. After other things settle a bit, we'll come back to this and properly fix it.
