### PR TITLE
2 newlines at the end of terminal report for now

### DIFF
--- a/src/napkin_diagnostics.ml
+++ b/src/napkin_diagnostics.ml
@@ -136,14 +136,12 @@ let explain t =
     end
 
 let toString t src =
-  let ppf = Format.err_formatter in
   Napkin_diagnostics_printing_utils.Super_location.super_error_reporter
-    ppf
+    Format.err_formatter
     ~src
     ~startPos:t.startPos
     ~endPos:t.endPos
-    ~msg:(explain t);
-  Format.pp_print_flush ppf ()
+    ~msg:(explain t)
 
 let make ~startPos ~endPos category = {
   startPos;
@@ -152,7 +150,9 @@ let make ~startPos ~endPos category = {
 }
 
 let printReport diagnostics src =
-  List.rev diagnostics |> List.iter (fun d -> toString d src)
+  Format.fprintf Format.err_formatter "@[<v>";
+  List.rev diagnostics |> List.iter (fun d -> toString d src);
+  Format.fprintf Format.err_formatter "@]@."
 
 let unexpected token context =
   Unexpected {token; context}

--- a/src/napkin_diagnostics_printing_utils.ml
+++ b/src/napkin_diagnostics_printing_utils.ml
@@ -229,6 +229,6 @@ let print src startPos endPos ppf () =
 let super_error_reporter ppf ~src ~startPos ~endPos ~msg =
   setup_colors ();
   (* open a vertical box. Everything in our message is indented 2 spaces *)
-  Format.fprintf ppf "@[<v 2>@,%a@,%s@,@]" (print src startPos endPos) () msg;
+  Format.fprintf ppf "@[<v 2>@,%a@,%s@]@," (print src startPos endPos) () msg;
 
 end

--- a/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/expressions/__snapshots__/parse.spec.js.snap
@@ -17,7 +17,7 @@ let x = ((let a = 1 in let b = 2 in fun pattern -> (\\"test\\" : int))
   1) (b): int => \\"hi\\"
   2) (b: int) => \\"hi\\"
 
-  
+
   Syntax error!
   parsing/errors/expressions/ambiguousArrow.js 6:3-23  
   4 │   let a = 1
@@ -30,7 +30,8 @@ let x = ((let a = 1 in let b = 2 in fun pattern -> (\\"test\\" : int))
   1) (pattern): int => \\"test\\"
   2) (pattern: int) => \\"test\\"
 
-  
+
+
 ========================================================"
 `;
 
@@ -46,7 +47,8 @@ let xs = x.map (fun key -> [|key;(predicates.(key))|])
   3 │ 
   
   Did you forget a \`]\` here? 
-  
+
+
 ========================================================"
 `;
 
@@ -64,7 +66,8 @@ exports[`arrow.js 1`] = `
   3 │   let b = 2
   
   Did you forget a \`,\` here? 
-  
+
+
 ========================================================"
 `;
 
@@ -104,7 +107,7 @@ let pipeline =
   17 │ let x = {
   
   Did you forget a \`)\` here? 
-  
+
   Syntax error!
   parsing/errors/expressions/block.js 18:25-19:1  
   16 │ 
@@ -115,7 +118,7 @@ let pipeline =
   21 │ switch stack {
   
   Did you forget a \`)\` here? 
-  
+
   Syntax error!
   parsing/errors/expressions/block.js 22:11-23:1  
   20 │ 
@@ -126,7 +129,7 @@ let pipeline =
   25 │ 	buffer->Buffer.add_string(indentation)
   
   Looks like there might be an expression missing here
-  
+
   Syntax error!
   parsing/errors/expressions/block.js 26:7-27:1  
   24 │ | Join(doc1, doc2) =>
@@ -137,7 +140,7 @@ let pipeline =
   29 │ let pipeline = switch scheduler {
   
   Did you forget a \`)\` here? 
-  
+
   Syntax error!
   parsing/errors/expressions/block.js 30:10-31:1  
   28 │ 
@@ -148,7 +151,8 @@ let pipeline =
   33 │ 
   
   Looks like there might be an expression missing here
-  
+
+
 ========================================================"
 `;
 
@@ -168,7 +172,7 @@ let () = ((let open Foo in let exception End  in x ())[@ns.braces ])
   3 │ let f = (g, h) => {
   
   consecutive statements on a line must be separated by ';' or a newline
-  
+
   Syntax error!
   parsing/errors/expressions/consecutive.res 4:7  
   2 │ 
@@ -178,7 +182,7 @@ let () = ((let open Foo in let exception End  in x ())[@ns.braces ])
   6 │ 
   
   consecutive expressions on a line must be separated by ';' or a newline
-  
+
   Syntax error!
   parsing/errors/expressions/consecutive.res 8:16-27  
    6 │ 
@@ -188,7 +192,7 @@ let () = ((let open Foo in let exception End  in x ())[@ns.braces ])
   10 │ 
   
   consecutive expressions on a line must be separated by ';' or a newline
-  
+
   Syntax error!
   parsing/errors/expressions/consecutive.res 12:11-20  
   10 │ 
@@ -198,7 +202,8 @@ let () = ((let open Foo in let exception End  in x ())[@ns.braces ])
   14 │ }
   
   consecutive expressions on a line must be separated by ';' or a newline
-  
+
+
 ========================================================"
 `;
 
@@ -215,7 +220,7 @@ let f a b = ((())[@ns.braces ])
   3 │ let f = (a, b) => {}
   
   This let-binding misses an expression
-  
+
   Syntax error!
   parsing/errors/expressions/emptyBlock.js 3:20  
   1 │ let x = {}
@@ -224,7 +229,8 @@ let f a b = ((())[@ns.braces ])
   4 │ 
   
   Missing expression
-  
+
+
 ========================================================"
 `;
 
@@ -242,7 +248,8 @@ exports[`if.js 1`] = `
   5 │ }
   
   Did you forget a \`{\` here? 
-  
+
+
 ========================================================"
 `;
 
@@ -272,7 +279,7 @@ switch result {
 | _ => ()
 }
 
-  
+
   Syntax error!
   parsing/errors/expressions/ifLet.res 7:8-11:1  
    5 │ if let Error(x) = result {
@@ -291,7 +298,8 @@ switch result {
 | _ => ()
 }
 
-  
+
+
 ========================================================"
 `;
 
@@ -306,7 +314,8 @@ let x = ([%napkinscript.exprhole ]) + 1
   2 │ 
   
   \`_\` isn't a valid name.
-  
+
+
 ========================================================"
 `;
 
@@ -326,7 +335,7 @@ let record = { field = ([%napkinscript.exprhole ]) }
   5 │ 
   
   Did you forget a \`,\` here? 
-  
+
   Syntax error!
   parsing/errors/expressions/record.js 8:10-18  
    6 │ 
@@ -336,7 +345,7 @@ let record = { field = ([%napkinscript.exprhole ]) }
   10 │ }
   
   Did you forget a \`:\` here? 
-  
+
   Syntax error!
   parsing/errors/expressions/record.js 13:9-17:0  
   11 │ 
@@ -348,7 +357,8 @@ let record = { field = ([%napkinscript.exprhole ]) }
   17 │ 
   
   Missing expression
-  
+
+
 ========================================================"
 `;
 
@@ -370,7 +380,8 @@ exports[`setField.js 1`] = `
   7 │ }
   
   It seems that this record field mutation misses an expression
-  
+
+
 ========================================================"
 `;
 
@@ -385,7 +396,8 @@ exports[`taggedTemplateLiterals.js 1`] = `
   2 │ 
   
   Tagged template literals are currently restricted to identifiers like: json\`null\`.
-  
+
+
 ========================================================"
 `;
 
@@ -402,7 +414,8 @@ let parsedPayload = try Js.Json.parseExn response with | _ -> Js.Json.null
   4 ┆   }
   
   Did you forget a \`catch\` here? 
-  
+
+
 ========================================================"
 `;
 
@@ -423,7 +436,7 @@ let x = (\\"hi\\" : string)
   Expressions with type constraints need to be wrapped in parens:
   (a + b: int)
 
-  
+
   Syntax error!
   parsing/errors/expressions/unexpectedConstraint.js 7:9-20  
   5 │ }
@@ -434,6 +447,7 @@ let x = (\\"hi\\" : string)
   Expressions with type constraints need to be wrapped in parens:
   (\\"hi\\": string)
 
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/other/__snapshots__/parse.spec.js.snap
@@ -12,7 +12,8 @@ exports[`patternMatching.js 1`] = `
   3 │ 
   
   Pattern matching needs at least one case
-  
+
+
 ========================================================"
 `;
 
@@ -33,7 +34,7 @@ let x::y = myList
   3 │ 
   
   Arrays can't use the \`...\` spread currently. Please use \`concat\` or other Array helpers.
-  
+
   Syntax error!
   parsing/errors/other/spread.js 2:6-8  
   1 │ let arr = [...x, ...y]
@@ -44,7 +45,7 @@ let x::y = myList
   Array's \`...\` spread is not supported in pattern matches.
 Explanation: such spread would create a subarray; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
 Solution: if it's to validate the first few elements, use a \`when\` clause + Array size check + \`get\` checks on the current pattern. If it's to obtain a subarray, use \`Array.sub\` or \`Belt.Array.slice\`.
-  
+
   Syntax error!
   parsing/errors/other/spread.js 4:21-23  
   2 │ let [...arr, _] = [1, 2, 3]
@@ -55,7 +56,7 @@ Solution: if it's to validate the first few elements, use a \`when\` clause + Ar
   
   Records can only have one \`...\` spread, at the beginning.
 Explanation: since records have a known, fixed shape, a spread like \`{a, ...b}\` wouldn't make sense, as \`b\` would override every field of \`a\` anyway.
-  
+
   Syntax error!
   parsing/errors/other/spread.js 5:15-18  
   3 │ 
@@ -67,7 +68,7 @@ Explanation: since records have a known, fixed shape, a spread like \`{a, ...b}\
   Record's \`...\` spread is not supported in pattern matches.
 Explanation: you can't collect a subset of a record's field into its own record, since a record needs an explicit declaration and that subset wouldn't have one.
 Solution: you need to pull out each field you want explicitly.
-  
+
   Syntax error!
   parsing/errors/other/spread.js 8:13-22  
   6 │ 
@@ -77,6 +78,7 @@ Solution: you need to pull out each field you want explicitly.
   
   List pattern matches only supports one \`...\` spread, at the end.
 Explanation: a list spread at the tail is efficient, but a spread in the middle would create new list[s]; out of performance concern, our pattern matching currently guarantees to never create new intermediate data.
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/pattern/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/pattern/__snapshots__/parse.spec.js.snap
@@ -14,7 +14,7 @@ let 4 = for [%napkinscript.patternhole ] = 0 to 10 do Js.log \\"for\\" done
   3 │ 
   
   I was expecting a name for this let-binding. Example: \`let message = \\"hello\\"\`
-  
+
   Syntax error!
   parsing/errors/pattern/missing.res 2:5  
   1 │ let = 2
@@ -23,7 +23,7 @@ let 4 = for [%napkinscript.patternhole ] = 0 to 10 do Js.log \\"for\\" done
   4 │ for in 0 to 10 {
   
   I was expecting a name for this let-binding. Example: \`let message = \\"hello\\"\`
-  
+
   Syntax error!
   parsing/errors/pattern/missing.res 4:5-6  
   2 │ let = 4
@@ -33,7 +33,7 @@ let 4 = for [%napkinscript.patternhole ] = 0 to 10 do Js.log \\"for\\" done
   6 │ }
   
   A for-loop has the following form: \`for i in 0 to 10\`. Did you forget to supply a name before \`in\`?
-  
+
   Syntax error!
   parsing/errors/pattern/missing.res 9:3-4  
    7 │ 
@@ -43,6 +43,7 @@ let 4 = for [%napkinscript.patternhole ] = 0 to 10 do Js.log \\"for\\" done
   11 │ 
   
   I was expecting a pattern to match on before the \`=>\`
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/scanner/__snapshots__/parse.spec.js.snap
@@ -13,7 +13,7 @@ let x = \\"\\\\\\\\0AAA\\"
   3 │ let x = \\"\\\\oAAA\\"
   
   unknown escape sequence
-  
+
   Syntax error!
   parsing/errors/scanner/escapeSequence.js 3:10-11  
   1 │ let x = \\"\\\\0\\"
@@ -22,7 +22,8 @@ let x = \\"\\\\\\\\0AAA\\"
   4 │ 
   
   unknown escape sequence
-  
+
+
 ========================================================"
 `;
 
@@ -40,7 +41,7 @@ let newX = x +. (newVelocity *. secondPerFrame)
   
   Hmm, not sure what I should do here with this character.
 If you're trying to deref an expression, use \`foo.contents\` instead.
-  
+
   Syntax error!
   parsing/errors/scanner/oldDerefOp.js 2:46  
   1 │ let newVelocity = velocity +. a *. secondPerFrame^;
@@ -49,7 +50,8 @@ If you're trying to deref an expression, use \`foo.contents\` instead.
   
   Hmm, not sure what I should do here with this character.
 If you're trying to deref an expression, use \`foo.contents\` instead.
-  
+
+
 ========================================================"
 `;
 
@@ -65,7 +67,8 @@ exports[`unclosedComment.js 1`] = `
   3 │ 
   
   This comment seems to be missing a closing \`*/\`
-  
+
+
 ========================================================"
 `;
 
@@ -80,6 +83,7 @@ let z = \\"eof\\"
   2 │ 
   
   This string is missing a double quote at the end
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/signature/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/signature/__snapshots__/parse.spec.js.snap
@@ -15,7 +15,8 @@ val y : int
   5 │ let y: int
   
   I'm not sure what to parse here when looking at \\"}\\".
-  
+
+
 ========================================================"
 `;
 
@@ -34,7 +35,7 @@ val z2 : float[@@genType ]
   3 │ export z1: int export z2: float
   
   consecutive specifications on a line must be separated by ';' or a newline
-  
+
   Syntax error!
   parsing/errors/signature/consecutive.resi 3:15-21  
   1 │ let x: int let y: float
@@ -43,6 +44,7 @@ val z2 : float[@@genType ]
   4 │ 
   
   consecutive specifications on a line must be separated by ';' or a newline
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/structure/__snapshots__/parse.spec.js.snap
@@ -15,7 +15,8 @@ let y = 2
   5 │ let y = 2
   
   I'm not sure what to parse here when looking at \\"}\\".
-  
+
+
 ========================================================"
 `;
 
@@ -31,7 +32,8 @@ exception Bar
   2 │ 
   
   consecutive statements on a line must be separated by ';' or a newline
-  
+
+
 ========================================================"
 `;
 
@@ -50,7 +52,8 @@ module C = struct module T = (Fun)(struct ;;foo (a + c) (b + d) end) end
   8 │ 
   
   I'm not sure what to parse here when looking at \\")\\".
-  
+
+
 ========================================================"
 `;
 
@@ -91,7 +94,8 @@ module ClientSet =
   21 │ Js.log(\\"test\\") // should not be omitted
   
   I'm not sure what to parse here when looking at \\")\\".
-  
+
+
 ========================================================"
 `;
 
@@ -117,7 +121,7 @@ let (x : int1) = (int2 = 3 :> int3)
   4 │ )
   
   Did you forget a \`=\` here? 
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 8:12-13  
    6 │ let x = {
@@ -127,7 +131,7 @@ let (x : int1) = (int2 = 3 :> int3)
   10 │ }
   
   Did you forget a \`=\` here? 
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 14:19-26  
   12 │ let t = {
@@ -137,7 +141,7 @@ let (x : int1) = (int2 = 3 :> int3)
   16 │ }
   
   Did you forget a \`=\` here? 
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 18:39-20:3  
   16 │ }
@@ -149,7 +153,7 @@ let (x : int1) = (int2 = 3 :> int3)
   22 │ // no magic in the syntax
   
   This let-binding misses an expression
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 20:10-23:3  
   18 │ let keyTable: Belt.Map.String.t<int> =
@@ -162,7 +166,7 @@ let (x : int1) = (int2 = 3 :> int3)
   25 │ // no magic in the syntax
   
   This let-binding misses an expression
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 23:11-13  
   21 │ 
@@ -172,7 +176,7 @@ let (x : int1) = (int2 = 3 :> int3)
   25 │ // no magic in the syntax
   
   Did you forget a \`=\` here? 
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 26:6-8  
   24 │ 
@@ -182,7 +186,7 @@ let (x : int1) = (int2 = 3 :> int3)
   28 │ // no magic in the syntax
   
   Did you forget a \`=\` here? 
-  
+
   Syntax error!
   parsing/errors/structure/letBinding.js 29:13-15  
   27 │ 
@@ -191,7 +195,8 @@ let (x : int1) = (int2 = 3 :> int3)
   30 │ 
   
   Did you forget a \`=\` here? 
-  
+
+
 ========================================================"
 `;
 
@@ -208,7 +213,7 @@ let [%napkinscript.patternhole ] = 3
   3 │ 
   
   \`open\` is a reserved keyword. Keywords need to be escaped: \\\\\\"open\\"
-  
+
   Syntax error!
   parsing/errors/structure/letBindingPatternKeyword.js 2:5-6  
   1 │ let open = 1
@@ -216,6 +221,7 @@ let [%napkinscript.patternhole ] = 3
   3 │ 
   
   \`to\` is a reserved keyword. Keywords need to be escaped: \\\\\\"to\\"
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typeDef/__snapshots__/parse.spec.js.snap
@@ -16,7 +16,8 @@ type nonrec 'a node =
   4 │ 
   
   An inline record declaration needs at least one field
-  
+
+
 ========================================================"
 `;
 
@@ -32,7 +33,8 @@ type nonrec record = {
   2 │ 
   
   A record needs at least one field
-  
+
+
 ========================================================"
 `;
 
@@ -47,7 +49,8 @@ type nonrec draw = stroke:pencil -> unit
   2 │ 
   
   Parameter names start with a \`~\`, like: ~stroke
-  
+
+
 ========================================================"
 `;
 
@@ -66,7 +69,7 @@ type t = [ [%napkinscript.typehole ] | [%napkinscript.typehole ]]
   3 │ type t = [ s ]
   
   I'm not sure what to parse here when looking at \\"]\\".
-  
+
   Syntax error!
   parsing/errors/typeDef/polyvariant.js 3:13-14  
   1 │ type t = [< ]
@@ -76,7 +79,7 @@ type t = [ [%napkinscript.typehole ] | [%napkinscript.typehole ]]
   5 │ type z = [< | #A | #B > ]
   
   Did you forget a \`|\` here? 
-  
+
   Syntax error!
   parsing/errors/typeDef/polyvariant.js 7:15  
   5 │ type z = [< | #A | #B > ]
@@ -86,7 +89,8 @@ type t = [ [%napkinscript.typehole ] | [%napkinscript.typehole ]]
   9 │ 
   
   I'm not sure what to parse here when looking at \\"]\\".
-  
+
+
 ========================================================"
 `;
 
@@ -106,7 +110,8 @@ type nonrec observation =
   5 │ 
   
   I'm missing a type here
-  
+
+
 ========================================================"
 `;
 
@@ -126,7 +131,7 @@ type nonrec state = [%napkinscript.typehole ]
   4 │ // missing type
   
   Did you forget a \`=\` here? 
-  
+
   Syntax error!
   parsing/errors/typeDef/typeDef.js 8:1-4  
   6 │ 
@@ -135,7 +140,7 @@ type nonrec state = [%napkinscript.typehole ]
   9 │ 
   
   Missing a type here
-  
+
   Syntax error!
   parsing/errors/typeDef/typeDef.js 9:1  
   7 │ // missing type
@@ -143,7 +148,8 @@ type nonrec state = [%napkinscript.typehole ]
   9 │ 
   
   Missing a type here
-  
+
+
 ========================================================"
 `;
 
@@ -178,7 +184,7 @@ type nonrec ('from, 'foo) derivedNode =
   Type parameters require angle brackets:
   node<'a>
 
-  
+
   Syntax error!
   parsing/errors/typeDef/typeParams.js 5:26-27  
   3 │ }
@@ -188,7 +194,7 @@ type nonrec ('from, 'foo) derivedNode =
   7 │   updateF: 'from => 'to_,
   
   \`to\` is a reserved keyword. Keywords need to be escaped: \\\\\\"to\\"
-  
+
   Syntax error!
   parsing/errors/typeDef/typeParams.js 10:26  
    8 │ }
@@ -198,7 +204,7 @@ type nonrec ('from, 'foo) derivedNode =
   12 │   updateF: 'from => 'to_,
   
   A type param consists of a singlequote followed by a name like \`'a\` or \`'A\`
-  
+
   Syntax error!
   parsing/errors/typeDef/typeParams.js 15:26  
   13 │ }
@@ -208,7 +214,7 @@ type nonrec ('from, 'foo) derivedNode =
   17 │   updateF: 'from => 'to_,
   
   A type param consists of a singlequote followed by a name like \`'a\` or \`'A\`
-  
+
   Syntax error!
   parsing/errors/typeDef/typeParams.js 21:25-27  
   19 │ 
@@ -218,6 +224,7 @@ type nonrec ('from, 'foo) derivedNode =
   23 │   updateF: 'from => 'to_,
   
   Type params start with a singlequote: 'foo
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/errors/typexpr/__snapshots__/parse.spec.js.snap
@@ -27,7 +27,7 @@ module Error3 =
   4 │ module Error2 = {
   
   Did you forget a \`=>\` here? 
-  
+
   Syntax error!
   parsing/errors/typexpr/arrow.js 7:27-30  
   5 │   type observation ={
@@ -37,7 +37,7 @@ module Error3 =
   9 │ }
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
   Syntax error!
   parsing/errors/typexpr/arrow.js 14:26-29  
   12 │   type observation ={
@@ -47,7 +47,8 @@ module Error3 =
   16 │ }
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
+
 ========================================================"
 `;
 
@@ -87,7 +88,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   5 │ 
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 7:14-8:13  
    5 │ 
@@ -98,7 +99,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   10 │ 
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 13:14-14:13  
   11 │ type state = {
@@ -109,7 +110,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   16 │ 
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 19:14-20:1  
   17 │ type state = {
@@ -120,7 +121,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   22 │ type state = {
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 25:1  
   23 │   @bs.meth
@@ -130,7 +131,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   27 │ type state = {
   
   I'm missing a type here
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 28:10  
   26 │ 
@@ -140,7 +141,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   30 │ }
   
   I'm missing a type here
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 33:18  
   31 │ 
@@ -150,7 +151,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   35 │ }
   
   I'm missing a type here
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 37:25  
   35 │ }
@@ -160,7 +161,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   39 │   ..
   
   I'm missing a type here
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 40:8-41:8  
   38 │ type state = {
@@ -171,7 +172,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   43 │ 
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 46:3-11  
   44 │ type websocket = {
@@ -181,7 +182,7 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   48 │ 
   
   I'm missing a type here
-  
+
   Syntax error!
   parsing/errors/typexpr/bsObjSugar.js 50:7-51:0  
   48 │ 
@@ -190,7 +191,8 @@ type nonrec websocket = < id: [%napkinscript.typehole ]   >  Js.t
   51 │ 
   
   Did you forget a \`:\` here? It signals the start of a type
-  
+
+
 ========================================================"
 `;
 
@@ -207,7 +209,8 @@ external printName : name:unit -> unit = \\"printName\\"[@@bs.module
   3 │ 
   
   I'm not sure what to parse here when looking at \\"?\\".
-  
+
+
 ========================================================"
 `;
 
@@ -231,7 +234,7 @@ type nonrec t = int node option
   Type parameters require angle brackets:
   Js.Nullable.value<'a>
 
-  
+
   Syntax error!
   parsing/errors/typexpr/typeConstructorArgs.js 5:24-27  
   3 │ }
@@ -243,7 +246,7 @@ type nonrec t = int node option
   Type parameters require angle brackets:
   Belt.Map.t<'a>
 
-  
+
   Syntax error!
   parsing/errors/typexpr/typeConstructorArgs.js 6:32-35  
   4 │ 
@@ -255,7 +258,7 @@ type nonrec t = int node option
   Type parameters require angle brackets:
   Belt.Map.t<'a>
 
-  
+
   Syntax error!
   parsing/errors/typexpr/typeConstructorArgs.js 9:28  
    7 │ 
@@ -264,7 +267,8 @@ type nonrec t = int node option
   10 │ 
   
   I'm not sure what to parse here when looking at \\")\\".
-  
+
+
 ========================================================"
 `;
 
@@ -281,7 +285,7 @@ type nonrec 'A x = 'let
   3 │ 
   
   A type variable consists of a singlequote followed by a name like \`'a\` or \`'A\`
-  
+
   Syntax error!
   parsing/errors/typexpr/typeVar.res 2:15-17  
   1 │ type x<'A> = '_
@@ -289,6 +293,7 @@ type nonrec 'A x = 'let
   3 │ 
   
   \`let\` is a reserved keyword. Keywords need to be escaped: \\\\\\"let\\"
-  
+
+
 ========================================================"
 `;

--- a/tests/parsing/infiniteLoops/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/infiniteLoops/__snapshots__/parse.spec.js.snap
@@ -157,7 +157,8 @@ let removeNode rbt node =
   171 ┆ }
   
   Did you mean \`==\` here?
-  
+
+
 ========================================================"
 `;
 
@@ -178,7 +179,7 @@ let (a : action) = AddUser \\"test\\"
   3 │ let a: action = AddUser(\\"test\\")
   
   consecutive statements on a line must be separated by ';' or a newline
-  
+
   Syntax error!
   parsing/infiniteLoops/jsxChildren.js 1:22-29  
   1 │ type action = AddUser<string>
@@ -186,7 +187,8 @@ let (a : action) = AddUser \\"test\\"
   3 │ let a: action = AddUser(\\"test\\")
   
   Missing </string>
-  
+
+
 ========================================================"
 `;
 
@@ -597,7 +599,7 @@ include
   Type parameters require angle brackets:
   t<'value>
 
-  
+
   Syntax error!
   parsing/infiniteLoops/nonRecTypes.js 19:45-51  
   17 ┆   ~size: int,
@@ -607,7 +609,7 @@ include
   21 ┆ t('value) =
   
   consecutive statements on a line must be separated by ';' or a newline
-  
+
   Syntax error!
   parsing/infiniteLoops/nonRecTypes.js 67:26-68:3  
   65 │         };
@@ -619,7 +621,7 @@ include
   70 │   let nodeToRemove =
   
   I'm not sure what to parse here when looking at \\"let\\".
-  
+
   Syntax error!
   parsing/infiniteLoops/nonRecTypes.js 68:21-69:3  
   66 │ let has = (rbt, value) => _findNode(rbt, rootGet(rbt), value) !== None
@@ -631,7 +633,7 @@ include
   71 │     switch (leftGet(node), rightGet(node)) {
   
   I'm not sure what to parse here when looking at \\"let\\".
-  
+
   Syntax error!
   parsing/infiniteLoops/nonRecTypes.js 434:31-38  
   432 │     updateSum(Some(node), ~delta);
@@ -643,6 +645,7 @@ include
   Type parameters require angle brackets:
   oldNewVisibleNodes<'value>
 
-  
+
+
 ========================================================"
 `;


### PR DESCRIPTION
2 newlines turn into 1 inside bsb. Not sure why. Format is temporary, so
this'll do until we remove it completely.