### PR TITLE
Refactor parsing of string template literals.

### DIFF
--- a/src/napkin_parser.ml
+++ b/src/napkin_parser.ml
@@ -62,6 +62,13 @@ let rec next ?prevEndPos p =
    p.startPos <- startPos;
    p.endPos <- endPos
 
+let nextTemplateLiteralToken p =
+  let (startPos, endPos, token) = Scanner.scanTemplateLiteralToken p.scanner in
+  p.token <- token;
+  p.prevEndPos <- p.endPos;
+  p.startPos <- startPos;
+  p.endPos <- endPos
+
 let checkProgress ~prevEndPos ~result p =
   if p.endPos == prevEndPos
   then None

--- a/src/napkin_parser.mli
+++ b/src/napkin_parser.mli
@@ -28,6 +28,7 @@ val make: ?mode:mode -> ?line:int -> string -> string -> t
 val expect: ?grammar:Grammar.t -> Token.t -> t -> unit
 val optional: t -> Token.t -> bool
 val next: ?prevEndPos:Lexing.position -> t -> unit
+val nextTemplateLiteralToken: t -> unit
 val lookahead: t -> (t -> 'a) -> 'a
 val err:
   ?startPos:Lexing.position ->

--- a/src/napkin_scanner.mli
+++ b/src/napkin_scanner.mli
@@ -29,3 +29,5 @@ val setDiamondMode: t -> unit
 val popMode: t -> mode -> unit
 
 val reconsiderLessThan: t -> Napkin_token.t
+
+val scanTemplateLiteralToken: t -> (Lexing.position * Lexing.position * Napkin_token.t)

--- a/src/napkin_token.ml
+++ b/src/napkin_token.ml
@@ -1,4 +1,3 @@
-
 module Comment = Napkin_comment
 module CharacterCodes = Napkin_character_codes
 

--- a/tests/parsing/recovery/string/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/recovery/string/__snapshots__/parse.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`eof.js 1`] = `"let x = \\"eof here\\""`;
 
-exports[`es6template.js 1`] = `"let x = ({js|this contains |js} ^ foo) ^ {js|, missing closin|js}"`;
+exports[`es6template.js 1`] = `"let x = ({js|this contains |js} ^ foo) ^ {js|, missing closing|js}"`;
 
 exports[`unclosed.js 1`] = `
 "let x = \\"unclosed\\"


### PR DESCRIPTION
The previous approach put the scanner in "Template" mode when the parser
was going to parse template literals. This resulted in some very awkward
code; upon scanning a token there was logic checking whether we were
in "Template" mode. Every non-template literal token would pay for this
extra branch…

The new parsing strategy works differently: when the parser needs to
parse template literals, it just asks the scanner immediately for a
template literal token. This is both more performant and easier to reason
about. Template literals are a different language, it makes sense to
split this into a separate scanning function.

Benchmark results: (lower is better)
![Imagen 29-7-20 a las 8 50](https://user-images.githubusercontent.com/10634678/89334661-2822da80-d697-11ea-9c08-aac2e6ad3da6.JPG)

