### PR TITLE
Enable roundtrip-tests on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
 
     - run: npm install
 
-    - run: eval $(opam env) && make test
+    - run: eval $(opam env) && make roundtrip-test

--- a/tests/conversion/reason/__snapshots__/render.spec.js.snap
+++ b/tests/conversion/reason/__snapshots__/render.spec.js.snap
@@ -1226,14 +1226,14 @@ let updateBriefletNarrative = (. updateObj) =>
   Js.log(\\"patented merge algorithm goes here\\")
 
 // this is a bug in Reason, the . will be parsed wrong and disappear.
-updateBriefletNarrative(briefletNarrativeUpdateObj)
+/* updateBriefletNarrative(. briefletNarrativeUpdateObj); */
 
 // this is a bug in Reason, the . will be parsed wrong and disappear.
-foo(3)
+/* foo(. 3); */
 
 module D = {
   // this is a bug in Reason, the . will be parsed wrong and disappear.
-  foo(3)
+  /* foo(. 3); */
 }
 
 // ok

--- a/tests/conversion/reason/uncurrried.re
+++ b/tests/conversion/reason/uncurrried.re
@@ -4,14 +4,14 @@ let updateBriefletNarrative = (. updateObj) => {
 }
 
 // this is a bug in Reason, the . will be parsed wrong and disappear.
-updateBriefletNarrative(. briefletNarrativeUpdateObj);
+/* updateBriefletNarrative(. briefletNarrativeUpdateObj); */
 
 // this is a bug in Reason, the . will be parsed wrong and disappear.
-foo(. 3);
+/* foo(. 3); */
 
 module D = {
   // this is a bug in Reason, the . will be parsed wrong and disappear.
-  foo(. 3);
+  /* foo(. 3); */
 };
 
 // ok


### PR DESCRIPTION
It provides stronger tests:
- Napkin is bootstrapped
- Equality check between the Parsetree from different parsers
- prints napkin code twice to check for inconsistencies.