### PR TITLE
Light weight exotic poly variant syntax

### DIFF
--- a/src/napkin_core.ml
+++ b/src/napkin_core.ml
@@ -490,7 +490,12 @@ let parseIdent ~msg ~startPos p =
 
 let parseHashIdent ~startPos p =
   Parser.expect Hash p;
-  parseIdent ~startPos ~msg:ErrorMessages.variantIdent p
+  match p.token with
+  | String text ->
+    Parser.next p;
+    (text, mkLoc startPos p.prevEndPos)
+  | _ ->
+    parseIdent ~startPos ~msg:ErrorMessages.variantIdent p
 
 (* Ldot (Ldot (Lident "Foo", "Bar"), "baz") *)
 let parseValuePath p =
@@ -1081,7 +1086,13 @@ let rec parsePattern ?(alias=true) ?(or_=true) p =
       let loc = mkLoc startPos ident.loc.loc_end in
       Ast_helper.Pat.type_ ~loc ~attrs ident
     ) else (
-      let (ident, loc) = parseIdent ~msg:ErrorMessages.variantIdent ~startPos p in
+      let (ident, loc) = match p.token with
+      | String text ->
+        Parser.next p;
+        (text, mkLoc startPos p.prevEndPos)
+      | _ ->
+        parseIdent ~msg:ErrorMessages.variantIdent ~startPos p
+      in
       begin match p.Parser.token with
       | Lparen ->
         parseVariantPatternArgs p ident startPos attrs

--- a/src/napkin_printer.ml
+++ b/src/napkin_printer.ml
@@ -359,6 +359,17 @@ let printIdentLike ?allowUident txt =
     ]
   | NormalIdent -> Doc.text txt
 
+(* Exotic identifiers in poly-vars have a "lighter" syntax: #"ease-in" *)
+let printPolyVarIdent txt =
+  match classifyIdentContent ~allowUident:true txt with
+  | ExoticIdent -> Doc.concat [
+      Doc.text "\"";
+      Doc.text txt;
+      Doc.text"\""
+    ]
+  | NormalIdent -> Doc.text txt
+
+
 let printLident l = match l with
   | Longident.Lident txt -> printIdentLike txt
   | Longident.Ldot (path, txt) ->
@@ -1615,7 +1626,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
     | Parsetree.Rtag ({txt}, attrs, true, []) ->
       Doc.concat [
         printAttributes attrs cmtTbl;
-        Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true txt]
+        Doc.concat [Doc.text "#"; printPolyVarIdent txt]
       ]
     | Rtag ({txt}, attrs, truth, types) ->
       let doType t = match t.Parsetree.ptyp_desc with
@@ -1627,7 +1638,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
       let cases = if truth then Doc.concat [Doc.line; Doc.text "& "; cases] else cases in
       Doc.group (Doc.concat [
         printAttributes attrs cmtTbl;
-        Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true txt];
+        Doc.concat [Doc.text "#"; printPolyVarIdent txt];
         cases
       ])
     | Rinherit coreType ->
@@ -1648,7 +1659,7 @@ and printTypExpr (typExpr : Parsetree.core_type) cmtTbl =
     | Some([]) ->
       Doc.nil
     | Some(labels) ->
-      Doc.concat (List.map (fun label -> Doc.concat [Doc.line; Doc.text "#" ; printIdentLike ~allowUident:true label] ) labels)
+      Doc.concat (List.map (fun label -> Doc.concat [Doc.line; Doc.text "#" ; printPolyVarIdent label] ) labels)
     in
     let closingSymbol = if hasLabels then Doc.text " >" else Doc.nil in
     Doc.group (
@@ -2159,10 +2170,10 @@ and printPattern (p : Parsetree.pattern) cmtTbl =
     in
     Doc.group(Doc.concat [constrName; argsDoc])
   | Ppat_variant (label, None) ->
-    Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true label]
+    Doc.concat [Doc.text "#"; printPolyVarIdent label]
   | Ppat_variant (label, variantArgs) ->
     let variantName =
-      Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true label] in
+      Doc.concat [Doc.text "#"; printPolyVarIdent label] in
     let argsDoc = match variantArgs with
     | None -> Doc.nil
     | Some({ppat_desc = Ppat_construct ({txt = Longident.Lident "()"}, _)}) ->
@@ -2609,7 +2620,7 @@ and printExpression (e : Parsetree.expression) cmtTbl =
     )
   | Pexp_variant (label, args) ->
     let variantName =
-      Doc.concat [Doc.text "#"; printIdentLike ~allowUident:true label] in
+      Doc.concat [Doc.text "#"; printPolyVarIdent label] in
     let args = match args with
     | None -> Doc.nil
     | Some({pexp_desc = Pexp_construct ({txt = Longident.Lident "()"}, _)}) ->

--- a/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/expressions/__snapshots__/parse.spec.js.snap
@@ -1095,7 +1095,12 @@ let switchExpr = match myVar with | Blue -> \\"blue\\" | Red -> \\"red\\"
 let constrainedExpr = (x : int)"
 `;
 
-exports[`polyvariant.js 1`] = `""`;
+exports[`polyvariant.js 1`] = `
+"let x = \`Red
+let z = \`Rgb ()
+let v = \`Vertex (1., 2., 3., 4.)
+let animation = \`ease-in"
+`;
 
 exports[`primary.js 1`] = `
 "let x = a.b

--- a/tests/parsing/grammar/expressions/polyvariant.js
+++ b/tests/parsing/grammar/expressions/polyvariant.js
@@ -1,7 +1,8 @@
-let x = `Red
-
+let x = #Red
 
 // sugar for Rgb(())
-let z = `Rgb()
+let z = #Rgb()
 
-let v = `Vertex(1., 2., 3., 4.)
+let v = #Vertex(1., 2., 3., 4.)
+
+let animation = #"ease-in"

--- a/tests/parsing/grammar/pattern/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/pattern/__snapshots__/parse.spec.js.snap
@@ -516,7 +516,8 @@ let cmp selectedChoice value =
   | (#a : typ) -> true
   | (lazy #a) -> true
   | exception #a -> true
-  | _ -> false"
+  | _ -> false
+;;match polyVar with | \`ease-in -> () | \`ease-out⛰ -> () | _ -> ()"
 `;
 
 exports[`record.js 1`] = `

--- a/tests/parsing/grammar/pattern/polyvariants.js
+++ b/tests/parsing/grammar/pattern/polyvariants.js
@@ -98,3 +98,9 @@ let cmp = (selectedChoice, value) =>
   | exception #...a => true
   | _ => false
   }
+
+switch polyVar {
+| #"ease-in" => ()
+| #"ease-out⛰" => ()
+| _ => ()
+}

--- a/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
+++ b/tests/parsing/grammar/typexpr/__snapshots__/parse.spec.js.snap
@@ -117,6 +117,8 @@ exports[`poly.js 1`] = `
       Js.t = \\"./src/logger.mock.js\\""
 `;
 
+exports[`polyVariant.res 1`] = `"type nonrec animation = [ \`ease-in  | \`ease-out  | \`never ease ✍️ ]"`;
+
 exports[`tuple.js 1`] = `
 "type nonrec t = (string * int)
 type nonrec t = (int option * string option)

--- a/tests/parsing/grammar/typexpr/polyVariant.res
+++ b/tests/parsing/grammar/typexpr/polyVariant.res
@@ -1,0 +1,5 @@
+type animation = [
+  | #"ease-in"
+  | #"ease-out"
+  | #"never ease ✍️"
+]

--- a/tests/printer/expr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/expr/__snapshots__/render.spec.js.snap
@@ -3013,13 +3013,13 @@ switch x {
 | #...typevar => 42
 }
 
-let r = #\\\\\\"Reducer⛪️\\"
-let r = #\\\\\\"type\\"(\\\\\\"module\\", \\\\\\"let\\")
+let r = #\\"Reducer⛪️\\"
+let r = #\\"type\\"(\\\\\\"module\\", \\\\\\"let\\")
 
 let r = #lident
 let r = #lident(a, b)
-let r = #\\\\\\"exotic lident\\"
-let r = #\\\\\\"exotic lident\\"(a, b)
+let r = #\\"exotic lident\\"
+let r = #\\"exotic lident\\"(a, b)
 "
 `;
 

--- a/tests/printer/pattern/__snapshots__/render.spec.js.snap
+++ b/tests/printer/pattern/__snapshots__/render.spec.js.snap
@@ -283,14 +283,14 @@ let list = 3
 exports[`variant.res 1`] = `
 "let #shape = x
 let #Shape = x
-let #\\\\\\"type\\" = x
-let #\\\\\\"test 🏚\\" = x
-let #\\\\\\"Shape✅\\" = x
+let #\\"type\\" = x
+let #\\"test 🏚\\" = x
+let #\\"Shape✅\\" = x
 
 let #Shape(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
 
-let #\\\\\\"type\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
-let #\\\\\\"Shape🎡\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
+let #\\"type\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
+let #\\"Shape🎡\\"(\\\\\\"module\\", \\\\\\"ExoticIdent\\") = x
 
 let cmp = (selectedChoice, value) =>
   switch (selectedChoice, value) {

--- a/tests/printer/typexpr/__snapshots__/render.spec.js.snap
+++ b/tests/printer/typexpr/__snapshots__/render.spec.js.snap
@@ -583,17 +583,17 @@ type color = [rgb | #Orange | #Yellow | #Purple]
 
 type t = [#variant]
 type t = [#Variant]
-type t = [#\\\\\\"type\\"]
-type t = [#\\\\\\"va r ia nt\\"]
-type t = [#\\\\\\"Variant ⛰\\"]
+type t = [#\\"type\\"]
+type t = [#\\"va r ia nt\\"]
+type t = [#\\"Variant ⛰\\"]
 
 let id = (x: [> #Red | #Green | #Blue]) => x
 let upper = (x: [< #Red | #Green]) => true
 type point = [#Point(float, float)]
-type \\\\\\"type\\" = [#\\\\\\"Point🗿\\"(\\\\\\"let\\", float)]
+type \\\\\\"type\\" = [#\\"Point🗿\\"(\\\\\\"let\\", float)]
 type shape = [#Rectangle(point, point) | #Circle(point, float)]
 
-type madness = [< #\\\\\\"type\\" & (\\\\\\"let\\") & (\\\\\\"Super exotic\\") | #\\\\\\"Bad Idea\\"]
+type madness = [< #\\"type\\" & (\\\\\\"let\\") & (\\\\\\"Super exotic\\") | #\\"Bad Idea\\"]
 
 let error_of_exn: exn => option<[#Ok(error) | #Already_displayed]> = x
 


### PR DESCRIPTION
Implements https://github.com/BuckleScript/syntax/issues/76

The syntax for exotic identifiers in poly-variants is quite heavy: `#\"ease-in"`.
By extending the syntax for poly-variants with the following, we get a lighter weight version that is more pleasant to read and write:
```
poly-var ::=
  HASH STRING
```
Example:
```ocaml
type animation = [ #"ease-in" | #"ease-out" ]
```

